### PR TITLE
feat: multi-model chat view for testing LLM connections

### DIFF
--- a/frontend/src/components/ChatPanel.vue
+++ b/frontend/src/components/ChatPanel.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="flex flex-col h-full min-h-0 border border-gray-200 rounded-lg bg-white overflow-hidden">
+    <!-- Panel header -->
+    <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-100 bg-gray-50 flex-shrink-0">
+      <span class="text-sm font-semibold text-gray-800 truncate">{{ modelName }}</span>
+      <div class="flex items-center gap-2 flex-shrink-0">
+        <span v-if="isStreaming" class="text-xs text-indigo-600 flex items-center gap-1">
+          <span class="inline-block w-1.5 h-1.5 rounded-full bg-indigo-500 animate-pulse" />
+          Streaming
+        </span>
+        <button
+          v-if="isStreaming"
+          class="btn-secondary text-xs py-0.5 px-2"
+          @click="abort"
+        >
+          Stop
+        </button>
+      </div>
+    </div>
+
+    <!-- Message list -->
+    <div ref="messageContainer" class="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
+      <!-- Empty state -->
+      <div v-if="turns.length === 0 && !isStreaming" class="h-full flex items-center justify-center">
+        <p class="text-sm text-gray-400">Send a message to start</p>
+      </div>
+
+      <!-- Completed turns -->
+      <template v-for="(turn, i) in turns" :key="i">
+        <div class="flex justify-end">
+          <div class="max-w-[85%] bg-indigo-50 border border-indigo-100 rounded-lg px-3 py-2">
+            <pre class="text-sm text-gray-800 whitespace-pre-wrap font-sans leading-relaxed">{{ turn.userContent }}</pre>
+          </div>
+        </div>
+        <div class="flex justify-start">
+          <div class="max-w-[85%] bg-white border border-gray-200 rounded-lg px-3 py-2 shadow-sm">
+            <pre class="text-sm text-gray-800 whitespace-pre-wrap font-sans leading-relaxed">{{ turn.assistantContent || '…' }}</pre>
+            <!-- Stats on last completed turn -->
+            <div v-if="i === turns.length - 1 && lastStats && !isStreaming" class="mt-2 flex gap-3 text-xs text-gray-400 border-t border-gray-100 pt-1.5">
+              <span v-if="lastStats.promptTokens">In: {{ lastStats.promptTokens }}</span>
+              <span v-if="lastStats.completionTokens">Out: {{ lastStats.completionTokens }}</span>
+              <span v-if="lastStats.latencyMs">{{ lastStats.latencyMs }}ms</span>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- Streaming turn (in progress) -->
+      <template v-if="isStreaming">
+        <div class="flex justify-end">
+          <div class="max-w-[85%] bg-indigo-50 border border-indigo-100 rounded-lg px-3 py-2">
+            <pre class="text-sm text-gray-800 whitespace-pre-wrap font-sans leading-relaxed">{{ currentUserContent }}</pre>
+          </div>
+        </div>
+        <div class="flex justify-start">
+          <div class="max-w-[85%] bg-white border border-gray-200 rounded-lg px-3 py-2 shadow-sm">
+            <pre class="text-sm text-gray-800 whitespace-pre-wrap font-sans leading-relaxed min-h-[1.5rem]">{{ streamingText }}<span class="inline-block w-2 h-4 bg-indigo-500 animate-pulse ml-0.5 align-text-bottom" /></pre>
+          </div>
+        </div>
+      </template>
+
+      <!-- Error -->
+      <ErrorAlert v-if="localError" :title="localError" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, nextTick } from 'vue'
+import { api } from '../api/client.js'
+import ErrorAlert from './ErrorAlert.vue'
+
+const props = defineProps({
+  modelName:          { type: String,  required: true },
+  pendingMessages:    { type: Array,   default: null },
+  sendTrigger:        { type: Number,  default: 0 },
+  stopTrigger:        { type: Number,  default: 0 },
+  temperature:        { type: Number,  default: 1.0 },
+  turns:              { type: Array,   default: () => [] },
+  currentUserContent: { type: String,  default: '' },
+  turnIndex:          { type: Number,  default: 0 },
+})
+
+const emit = defineEmits(['turn-complete', 'streaming-change', 'error'])
+
+const isStreaming = ref(false)
+const streamingText = ref('')
+const localError = ref('')
+const lastStats = ref(null)
+const messageContainer = ref(null)
+
+let abortController = null
+
+function scrollToBottom() {
+  nextTick(() => {
+    if (messageContainer.value) {
+      messageContainer.value.scrollTop = messageContainer.value.scrollHeight
+    }
+  })
+}
+
+// Fire streaming when parent increments sendTrigger
+watch(() => props.sendTrigger, (newVal) => {
+  if (newVal === 0 || !props.pendingMessages) return
+  runStreaming()
+})
+
+// Abort when parent increments stopTrigger
+watch(() => props.stopTrigger, () => {
+  abort()
+})
+
+async function runStreaming() {
+  localError.value = ''
+  streamingText.value = ''
+  lastStats.value = null
+  isStreaming.value = true
+  emit('streaming-change', { modelName: props.modelName, streaming: true })
+
+  const t0 = Date.now()
+  abortController = new AbortController()
+
+  try {
+    const body = await api.chatCompletionStream(props.modelName, props.pendingMessages, {
+      temperature: props.temperature,
+      signal: abortController.signal,
+    })
+
+    const reader = body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (!trimmed.startsWith('data: ')) continue
+          const data = trimmed.slice(6)
+          if (data === '[DONE]') {
+            lastStats.value = { latencyMs: Date.now() - t0 }
+            emit('turn-complete', {
+              modelName: props.modelName,
+              turnIndex: props.turnIndex,
+              content: streamingText.value,
+              stats: lastStats.value,
+            })
+            return
+          }
+          try {
+            const chunk = JSON.parse(data)
+            const content = chunk.choices?.[0]?.delta?.content
+            if (content) {
+              streamingText.value += content
+              scrollToBottom()
+            }
+          } catch { /* skip malformed chunk */ }
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+    // Stream ended without [DONE]
+    emit('turn-complete', {
+      modelName: props.modelName,
+      turnIndex: props.turnIndex,
+      content: streamingText.value,
+      stats: { latencyMs: Date.now() - t0 },
+    })
+  } catch (e) {
+    if (e.name !== 'AbortError') {
+      localError.value = e.message
+      emit('error', { modelName: props.modelName, error: e.message })
+    }
+    emit('turn-complete', {
+      modelName: props.modelName,
+      turnIndex: props.turnIndex,
+      content: streamingText.value,
+      stats: { latencyMs: Date.now() - t0 },
+    })
+  } finally {
+    isStreaming.value = false
+    abortController = null
+    emit('streaming-change', { modelName: props.modelName, streaming: false })
+    scrollToBottom()
+  }
+}
+
+function abort() {
+  abortController?.abort()
+}
+</script>

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -56,6 +56,7 @@ const hasKey = computed(() => !!apiKey.value)
 const links = [
   { to: '/', label: 'Dashboard' },
   { to: '/models', label: 'Models' },
+  { to: '/chat', label: 'Chat' },
   { to: '/logs', label: 'Logs' },
   { to: '/config', label: 'Config' },
   { to: '/api-docs', label: 'API Docs' },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,10 +5,12 @@ import LogsView from '../views/LogsView.vue'
 import ConfigView from '../views/ConfigView.vue'
 import SettingsView from '../views/SettingsView.vue'
 import ApiDocsView from '../views/ApiDocsView.vue'
+import ChatView from '../views/ChatView.vue'
 
 const routes = [
   { path: '/', name: 'dashboard', component: DashboardView },
   { path: '/models', name: 'models', component: ModelsView },
+  { path: '/chat', name: 'chat', component: ChatView },
   { path: '/logs', name: 'logs', component: LogsView },
   { path: '/config', name: 'config', component: ConfigView },
   { path: '/settings', name: 'settings', component: SettingsView },

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1,0 +1,287 @@
+<template>
+  <div class="flex flex-col h-[calc(100vh-4rem)] overflow-hidden">
+    <!-- Top controls bar -->
+    <div class="flex-shrink-0 border-b border-gray-200 bg-white px-4 sm:px-6 lg:px-8 py-3 space-y-3">
+      <!-- Heading row -->
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-xl font-semibold text-gray-900">Chat</h1>
+          <p class="text-xs text-gray-500 mt-0.5">Test models and compare responses side by side</p>
+        </div>
+        <button
+          v-if="sharedUserMsgs.length > 0"
+          class="btn-secondary text-sm"
+          :disabled="anyStreaming"
+          @click="clearAll"
+        >
+          Clear
+        </button>
+      </div>
+
+      <!-- Model selector -->
+      <div v-if="loadingModels" class="text-sm text-gray-400">Loading models…</div>
+      <div v-else-if="availableModels.length === 0" class="text-sm text-red-500 text-sm">
+        No models available — check your connection and API key
+      </div>
+      <div v-else class="flex flex-wrap gap-2">
+        <button
+          v-for="model in availableModels"
+          :key="model"
+          class="text-xs rounded-full px-3 py-1.5 border transition-colors"
+          :class="selectedModels.includes(model)
+            ? 'bg-indigo-600 text-white border-indigo-600'
+            : selectedModels.length >= 4
+              ? 'bg-white text-gray-400 border-gray-200 cursor-not-allowed'
+              : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'"
+          @click="toggleModel(model)"
+        >
+          {{ model }}
+        </button>
+      </div>
+
+      <!-- Advanced options (collapsible) -->
+      <details class="group">
+        <summary class="text-xs text-gray-500 cursor-pointer select-none list-none flex items-center gap-1 hover:text-gray-700 w-fit">
+          <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M6 6l8 4-8 4V6z" />
+          </svg>
+          Advanced options
+        </summary>
+        <div class="mt-2 flex flex-wrap items-start gap-4">
+          <div class="flex-1 min-w-[200px]">
+            <label class="block text-xs text-gray-600 mb-1">System message (optional)</label>
+            <textarea
+              v-model="systemMessage"
+              class="input resize-y text-sm font-mono"
+              rows="2"
+              placeholder="You are a helpful assistant."
+              :disabled="anyStreaming"
+            />
+          </div>
+          <div>
+            <label class="block text-xs text-gray-600 mb-1">Temperature: {{ temperature.toFixed(1) }}</label>
+            <input
+              type="range"
+              v-model.number="temperature"
+              min="0" max="2" step="0.1"
+              class="w-32 accent-indigo-600 block mt-2"
+              :disabled="anyStreaming"
+            />
+          </div>
+        </div>
+      </details>
+    </div>
+
+    <!-- Main area: panels or empty state -->
+    <div class="flex-1 min-h-0 overflow-hidden">
+      <div
+        v-if="selectedModels.length === 0"
+        class="h-full flex items-center justify-center"
+      >
+        <div class="text-center">
+          <svg class="w-12 h-12 text-gray-300 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+              d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+          </svg>
+          <p class="text-sm text-gray-500">Select one or more models above to start chatting</p>
+        </div>
+      </div>
+
+      <div
+        v-else
+        class="h-full p-4 gap-4 grid overflow-hidden"
+        :class="gridClass"
+      >
+        <ChatPanel
+          v-for="model in selectedModels"
+          :key="model"
+          :model-name="model"
+          :pending-messages="pendingMsgs[model] ?? null"
+          :send-trigger="sendTrigger"
+          :stop-trigger="stopTrigger"
+          :temperature="temperature"
+          :turns="completedTurnsFor(model)"
+          :current-user-content="currentUserContent"
+          :turn-index="currentTurnIndex"
+          @turn-complete="onTurnComplete"
+          @streaming-change="onStreamingChange"
+        />
+      </div>
+    </div>
+
+    <!-- Shared input bar -->
+    <div class="flex-shrink-0 border-t border-gray-200 bg-white px-4 sm:px-6 lg:px-8 py-3">
+      <div class="flex gap-3 items-end">
+        <div class="flex-1">
+          <textarea
+            v-model="userInput"
+            class="input resize-none text-sm"
+            rows="2"
+            placeholder="Type your message… (Ctrl+Enter to send)"
+            :disabled="anyStreaming || selectedModels.length === 0"
+            @keydown.ctrl.enter.prevent="send"
+            @keydown.meta.enter.prevent="send"
+          />
+        </div>
+        <div class="flex gap-2 flex-shrink-0">
+          <button
+            v-if="anyStreaming"
+            class="btn-secondary text-sm"
+            @click="stopAll"
+          >
+            Stop All
+          </button>
+          <button
+            class="btn-primary text-sm"
+            :disabled="anyStreaming || !userInput.trim() || selectedModels.length === 0"
+            @click="send"
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, computed, onMounted } from 'vue'
+import { api } from '../api/client.js'
+import ChatPanel from '../components/ChatPanel.vue'
+
+// ── Model list ─────────────────────────────────────────────────────────────
+const availableModels = ref([])
+const loadingModels = ref(true)
+
+onMounted(async () => {
+  try {
+    const data = await api.models()
+    availableModels.value = (data.data ?? []).map(m => m.id)
+  } catch {
+    /* silently ignore; empty state shown */
+  } finally {
+    loadingModels.value = false
+  }
+})
+
+// ── Model selection ────────────────────────────────────────────────────────
+const selectedModels = ref([])
+
+function toggleModel(model) {
+  const idx = selectedModels.value.indexOf(model)
+  if (idx >= 0) {
+    selectedModels.value.splice(idx, 1)
+    // Reset history for this model so it starts fresh if re-added later
+    delete assistantMsgs[model]
+  } else if (selectedModels.value.length < 4) {
+    selectedModels.value.push(model)
+    assistantMsgs[model] = []
+  }
+}
+
+// ── Conversation state ─────────────────────────────────────────────────────
+const sharedUserMsgs = ref([])    // string[] — user text per completed turn
+const assistantMsgs = reactive({}) // Record<model, string[]>
+const systemMessage = ref('')
+const temperature = ref(1.0)
+const userInput = ref('')
+
+// ── Trigger coordination ───────────────────────────────────────────────────
+const sendTrigger = ref(0)
+const stopTrigger = ref(0)
+const pendingMsgs = reactive({}) // Record<model, Message[]> — set before sendTrigger++
+const currentTurnIndex = ref(0)  // which turn is in-flight
+const currentUserContent = ref('') // user text for the in-flight turn
+
+// ── Streaming state ────────────────────────────────────────────────────────
+const streamingState = reactive({})
+
+const anyStreaming = computed(() =>
+  selectedModels.value.some(m => streamingState[m])
+)
+
+// ── Grid layout ────────────────────────────────────────────────────────────
+const gridClass = computed(() => {
+  switch (selectedModels.value.length) {
+    case 1:  return 'grid-cols-1'
+    case 2:  return 'grid-cols-2'
+    case 3:  return 'grid-cols-3'
+    default: return 'grid-cols-2' // 4 → 2×2
+  }
+})
+
+// ── History helpers ────────────────────────────────────────────────────────
+function buildHistoryForModel(model, turnIndex) {
+  const history = []
+  if (systemMessage.value.trim()) {
+    history.push({ role: 'system', content: systemMessage.value.trim() })
+  }
+  for (let i = 0; i < turnIndex; i++) {
+    history.push({ role: 'user', content: sharedUserMsgs.value[i] })
+    const reply = assistantMsgs[model]?.[i]
+    if (reply) history.push({ role: 'assistant', content: reply })
+  }
+  history.push({ role: 'user', content: sharedUserMsgs.value[turnIndex] })
+  return history
+}
+
+// Returns completed turns for a model as { userContent, assistantContent } pairs.
+// During streaming, only include turns before the in-flight one.
+function completedTurnsFor(model) {
+  const replies = assistantMsgs[model] ?? []
+  const limit = anyStreaming.value ? currentTurnIndex.value : sharedUserMsgs.value.length
+  return sharedUserMsgs.value.slice(0, limit).map((userContent, i) => ({
+    userContent,
+    assistantContent: replies[i] ?? '',
+  }))
+}
+
+// ── Send ───────────────────────────────────────────────────────────────────
+function send() {
+  if (!userInput.value.trim() || selectedModels.value.length === 0 || anyStreaming.value) return
+
+  const turnIndex = sharedUserMsgs.value.length
+  const content = userInput.value.trim()
+
+  // Commit the user message
+  sharedUserMsgs.value.push(content)
+  currentTurnIndex.value = turnIndex
+  currentUserContent.value = content
+  userInput.value = ''
+
+  // Pre-allocate assistant slots and build per-model message histories
+  for (const model of selectedModels.value) {
+    if (!assistantMsgs[model]) assistantMsgs[model] = []
+    assistantMsgs[model][turnIndex] = ''
+    pendingMsgs[model] = buildHistoryForModel(model, turnIndex)
+  }
+
+  // Increment trigger — all panels watching this will fire their stream
+  sendTrigger.value++
+}
+
+// ── Stop all ───────────────────────────────────────────────────────────────
+function stopAll() {
+  stopTrigger.value++
+}
+
+// ── Event handlers ─────────────────────────────────────────────────────────
+function onTurnComplete({ modelName, turnIndex, content }) {
+  if (!assistantMsgs[modelName]) assistantMsgs[modelName] = []
+  assistantMsgs[modelName][turnIndex] = content
+}
+
+function onStreamingChange({ modelName, streaming }) {
+  streamingState[modelName] = streaming
+}
+
+// ── Clear all ──────────────────────────────────────────────────────────────
+function clearAll() {
+  sharedUserMsgs.value = []
+  currentTurnIndex.value = 0
+  currentUserContent.value = ''
+  for (const model of selectedModels.value) {
+    assistantMsgs[model] = []
+  }
+}
+</script>

--- a/frontend/tests/unit/components/NavBar.test.js
+++ b/frontend/tests/unit/components/NavBar.test.js
@@ -22,6 +22,7 @@ function makeRouter() {
     routes: [
       { path: '/', component: { template: '<div/>' } },
       { path: '/models', component: { template: '<div/>' } },
+      { path: '/chat', component: { template: '<div/>' } },
       { path: '/logs', component: { template: '<div/>' } },
       { path: '/config', component: { template: '<div/>' } },
       { path: '/api-docs', component: { template: '<div/>' } },
@@ -42,6 +43,7 @@ describe('NavBar', () => {
     const text = wrapper.text()
     expect(text).toContain('Dashboard')
     expect(text).toContain('Models')
+    expect(text).toContain('Chat')
     expect(text).toContain('Logs')
     expect(text).toContain('Config')
     expect(text).toContain('API Docs')


### PR DESCRIPTION
## Summary

Implements pridkett/simple-llm-proxy#11 — a dedicated Chat page in the admin frontend for testing LLM connections and comparing model responses.

- **Model selection**: Toggle pills for each available model (up to 4 simultaneously)
- **Multi-model parallel queries**: Send a message to all selected models at once; each streams its response independently in a side-by-side panel
- **Multi-turn conversation history**: Full chat history is maintained and sent with each request — each model receives the shared user messages interleaved with its own prior assistant replies
- **Streaming**: SSE streaming with per-panel Stop button and a global Stop All button
- **Grid layout**: Adapts to number of selected models (1→full, 2→2-col, 3→3-col, 4→2×2)
- **Advanced options**: Collapsible system message and temperature controls

## Implementation notes

- `ChatView.vue` owns all shared state. Coordinates panels via `sendTrigger`/`stopTrigger` counter props (incremented to fire watches in children — idiomatic Vue 3 without `$refs`)
- `ChatPanel.vue` handles streaming for one model. The SSE loop is copied directly from the proven `ModelPlayground.vue` pattern
- Conversation state: shared user messages array + per-model assistant replies array, interleaved at call time — minimizes redundancy vs. duplicating full state per model
- All 89 existing tests pass; NavBar test updated to include the new `/chat` route

## Test plan

- [ ] Navigate to Chat; verify model pills load from `/v1/models`
- [ ] Select 1 model, send a message; verify streaming response appears with cursor
- [ ] Send a follow-up; verify conversation history is included (check Network tab — messages array has alternating user/assistant)
- [ ] Select 2-4 models; verify panels render side-by-side and all respond in parallel
- [ ] Test per-panel Stop button; verify streaming halts mid-response
- [ ] Test Stop All button; verify all streaming panels halt
- [ ] Test Clear; verify all panels reset
- [ ] Deselect and re-select a model; verify it starts fresh (no stale history)
- [x] `npm test` — 89 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)