### PR TITLE
feat(auth): Phase 1 — Auth & Identity (SSO, teams, applications)

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -95,9 +95,9 @@ export const api = {
     return request(`/admin/logs${query}`)
   },
 
-  /** GET /v1/models */
+  /** GET /admin/models */
   models() {
-    return request('/v1/models')
+    return request('/admin/models')
   },
 
   /**
@@ -109,7 +109,7 @@ export const api = {
   chatCompletion(model, messages, options = {}) {
     const body = { model, messages, stream: false }
     if (options.temperature !== undefined) body.temperature = options.temperature
-    return request('/v1/chat/completions', { method: 'POST', body: JSON.stringify(body) })
+    return request('/admin/chat/completions', { method: 'POST', body: JSON.stringify(body) })
   },
 
   /**
@@ -123,7 +123,7 @@ export const api = {
     const body = { model, messages, stream: true }
     if (options.temperature !== undefined) body.temperature = options.temperature
 
-    const res = await fetch(`${BASE_URL}/v1/chat/completions`, {
+    const res = await fetch(`${BASE_URL}/admin/chat/completions`, {
       method: 'POST',
       credentials: 'include', // HttpOnly session cookie
       headers: {
@@ -182,7 +182,7 @@ export const api = {
    * @param {string} modelName
    */
   modelDetail(modelName) {
-    return request(`/v1/models/${encodeURIComponent(modelName)}`)
+    return request(`/admin/models/${encodeURIComponent(modelName)}`)
   },
 
   /**

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -20,6 +20,10 @@ export default defineConfig({
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
+      '/auth': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
       '/health': {
         target: 'http://localhost:8080',
         changeOrigin: true,

--- a/internal/api/handler/auth.go
+++ b/internal/api/handler/auth.go
@@ -164,7 +164,7 @@ func AuthCallback(oidcProvider *auth.OIDCProvider, store storage.Storage, sm *sc
 		sm.Put(ctx, "user_id", claims.Sub)
 
 		// 10. Redirect to frontend dashboard
-		http.Redirect(w, r, "/#/dashboard", http.StatusFound)
+		http.Redirect(w, r, "/#/", http.StatusFound)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -79,6 +79,12 @@ func NewRouter(r *router.Router, store storage.Storage, reloader *config.Reloade
 		mux.Post("/admin/costmap/reload", handler.AdminCostMapReload(cm))
 		mux.Put("/admin/costmap/url", handler.AdminCostMapSetURL(cm))
 
+		// Model endpoints mirrored for session-auth browser clients
+		mux.Get("/admin/models", handler.Models(r))
+		mux.Get("/admin/models/{model}", handler.ModelDetail(r, cm))
+		mux.Post("/admin/chat/completions", handler.ChatCompletions(r, store))
+		mux.Post("/admin/embeddings", handler.Embeddings(r, store))
+
 		// Identity CRUD routes registered by Plan 05 via RegisterAdminRoutes
 		handler.RegisterAdminRoutes(mux, store)
 	})

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -104,6 +104,28 @@ func Parse(data []byte) (*Config, error) {
 		}
 	}
 
+	// Process oidc_settings
+	if os, ok := raw["oidc_settings"].(map[string]any); ok {
+		if v, ok := os["issuer_url"].(string); ok {
+			cfg.OIDCSettings.IssuerURL = v
+		}
+		if v, ok := os["client_id"].(string); ok {
+			cfg.OIDCSettings.ClientID = expandEnvVar(v)
+		}
+		if v, ok := os["client_secret"].(string); ok {
+			cfg.OIDCSettings.ClientSecret = expandEnvVar(v)
+		}
+		if v, ok := os["redirect_url"].(string); ok {
+			cfg.OIDCSettings.RedirectURL = v
+		}
+		if v, ok := os["admin_group"].(string); ok {
+			cfg.OIDCSettings.AdminGroup = v
+		}
+		if v, ok := os["dev_mode"].(bool); ok {
+			cfg.OIDCSettings.DevMode = v
+		}
+	}
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of the Multi-User Proxy milestone: full SSO identity layer built on PocketID OIDC, team/application organization, and RBAC enforcement.

- **SSO authentication** via PocketID OIDC (authorization code flow with nonce + state validation, session fixation mitigation)
- **Session management** using `alexedwards/scs` with SQLite-backed store; HttpOnly cookie, 24h lifetime, 2h idle timeout
- **Identity storage**: 5 new SQLite tables (`users`, `teams`, `team_members`, `applications`, `sessions`) with cascade deletes
- **Admin REST API**: CRUD endpoints for users, teams (with member/role management), and applications — all admin-enforced
- **Frontend**: Login view, session composable singleton, router guards with 401 loop prevention, Users/Teams/Applications admin views
- **UAT bug fixes**: config loader missing `oidc_settings` parse, missing `/auth` Vite proxy rule, wrong post-login redirect path, `/v1/*` model endpoints inaccessible to session-auth browser clients (mirrored under `/admin/`)

Implements pridkett/simple-llm-proxy#17
ADR: `adr/003-auth-identity-design.md`

## What's verified

- 14/14 automated must-haves pass (go test ./... + npm test, 107 frontend tests)
- Human UAT in progress against live PocketID instance — SSO flow, session persistence, team/application CRUD

## Known gaps

- **PKCE not implemented** (ADR 003 Decision 15 requires it) — `oauth2.S256ChallengeOption` absent from `AuthLogin`. Functional but reduces security posture. Needs a follow-up issue.
- `useAuth.js` remains imported by `SettingsView.vue` for master API key management — this is intentional (master key ≠ session token) but the original plan comment said it would be removed.

## Test plan

- [ ] Sign in via PocketID SSO → session cookie set → land on dashboard
- [ ] Refresh browser → session persists, no redirect to login
- [ ] Delete session cookie in DevTools → navigate to /users → redirect to /login cleanly
- [ ] Navigate to /users as admin → full user list with Admin badges
- [ ] Create team, add member, change role, remove member, delete team
- [ ] Create application scoped to team, delete it
- [ ] Sign in as non-admin → /admin/users returns 403, /admin/teams/mine returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)