### PR TITLE
fix(phase1-uat): resolve UAT bugs in Teams and Applications views

### DIFF
--- a/frontend/src/views/ApplicationsView.vue
+++ b/frontend/src/views/ApplicationsView.vue
@@ -2,120 +2,166 @@
   <div class="p-6">
     <h1 class="text-2xl font-bold text-gray-900 mb-6">Applications</h1>
 
-    <!-- Team selector -->
-    <div class="mb-6">
-      <label for="team-select" class="block text-sm font-medium text-gray-700 mb-1">Filter by Team</label>
-      <select
-        id="team-select"
-        v-model="selectedTeamId"
-        @change="handleTeamChange"
-        class="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-      >
-        <option value="">Select a team...</option>
-        <option v-for="team in teams" :key="team.id" :value="String(team.id)">
-          {{ team.name }}
-        </option>
-      </select>
-    </div>
+    <div class="flex gap-6">
+      <!-- Left panel: team list -->
+      <div class="w-64 flex-shrink-0">
+        <!-- Filter input -->
+        <div class="mb-4">
+          <input
+            v-model="teamSearch"
+            type="text"
+            placeholder="Filter teams"
+            autocomplete="off"
+            data-1p-ignore
+            data-lpignore="true"
+            class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
 
-    <!-- Create application form (shown when team is selected, admin only) -->
-    <form
-      v-if="selectedTeamId && currentUser?.is_admin"
-      @submit.prevent="handleCreateApplication"
-      class="mb-6 flex gap-3 items-end"
-    >
-      <div>
-        <label class="block text-xs text-gray-500 mb-1">Application Name</label>
-        <input
-          v-model="newAppName"
-          type="text"
-          placeholder="Application name"
-          class="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        />
+        <div v-if="loadingTeams" class="text-gray-500 text-sm">Loading...</div>
+        <div v-else-if="teamsError" class="text-red-600 text-sm">{{ teamsError }}</div>
+        <ul v-else class="space-y-1">
+          <li
+            v-for="team in filteredTeams"
+            :key="team.id"
+            class="flex items-center justify-between px-3 py-2 rounded-md cursor-pointer text-sm"
+            :class="selectedTeam?.id === team.id ? 'bg-indigo-50 text-indigo-700' : 'text-gray-700 hover:bg-gray-50'"
+            @click="selectTeam(team)"
+          >
+            <span>{{ team.name }}</span>
+          </li>
+          <li v-if="filteredTeams.length === 0" class="px-3 py-2 text-sm text-gray-400 italic">
+            No teams found
+          </li>
+        </ul>
       </div>
-      <button
-        type="submit"
-        class="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 transition-colors"
-      >
-        Create
-      </button>
-    </form>
 
-    <!-- Applications list -->
-    <div v-if="loadingApps" class="text-gray-500 text-sm">Loading...</div>
-    <div v-else-if="appsError" class="text-red-600 text-sm">{{ appsError }}</div>
-    <div v-else-if="!selectedTeamId" class="text-gray-400 text-sm">Select a team to view applications.</div>
-    <table v-else class="min-w-full divide-y divide-gray-200">
-      <thead class="bg-gray-50">
-        <tr>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Team</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
-        </tr>
-      </thead>
-      <tbody class="bg-white divide-y divide-gray-200">
-        <tr v-for="app in applications" :key="app.id">
-          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ app.name }}</td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ teamName(app.team_id) }}</td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-            {{ new Date(app.created_at).toLocaleDateString() }}
-          </td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm">
-            <template v-if="pendingDeleteAppId === app.id">
-              <span class="text-xs text-gray-500 mr-1">Delete {{ app.name }}?</span>
+      <!-- Right panel: applications for selected team -->
+      <div v-if="selectedTeam" class="flex-1">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">{{ selectedTeam.name }} — Applications</h2>
+
+        <div v-if="loadingApps" class="text-gray-500 text-sm">Loading applications...</div>
+        <div v-else>
+          <!-- Applications table -->
+          <table class="min-w-full divide-y divide-gray-200 mb-6">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              <tr v-if="applications.length === 0">
+                <td colspan="3" class="px-4 py-8 text-center text-sm text-gray-400 italic">
+                  No applications yet — create the first one below
+                </td>
+              </tr>
+              <tr v-for="app in applications" :key="app.id">
+                <td class="px-4 py-3 text-sm font-medium text-gray-900">{{ app.name }}</td>
+                <td class="px-4 py-3 text-sm text-gray-500">
+                  {{ new Date(app.created_at).toLocaleDateString() }}
+                </td>
+                <td class="px-4 py-3 text-sm">
+                  <template v-if="pendingDeleteAppId === app.id">
+                    <span class="text-xs text-gray-500 mr-1">Delete {{ app.name }}?</span>
+                    <button
+                      :data-testid="`confirm-delete-app-${app.id}`"
+                      @click="confirmDeleteApp(app.id)"
+                      class="text-xs text-red-600 hover:text-red-800 mr-1 font-medium"
+                    >Yes</button>
+                    <button
+                      @click="pendingDeleteAppId = null"
+                      class="text-xs text-gray-500 hover:text-gray-700"
+                    >No</button>
+                  </template>
+                  <button
+                    v-else
+                    :data-testid="`delete-app-${app.id}`"
+                    @click="startDeleteApp(app.id)"
+                    class="text-xs text-red-500 hover:text-red-700"
+                  >Delete</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <!-- Inline error banner -->
+          <div v-if="appsError" class="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-600 flex justify-between items-center">
+            <span>{{ appsError }}</span>
+            <button @click="appsError = null" class="ml-3 text-red-400 hover:text-red-600">✕</button>
+          </div>
+
+          <!-- Create application form (admin only) -->
+          <div v-if="currentUser?.is_admin" class="border-t border-gray-200 pt-4">
+            <h3 class="text-sm font-medium text-gray-700 mb-3">New Application</h3>
+            <form @submit.prevent="handleCreateApplication" class="flex items-end gap-3">
+              <div>
+                <label class="block text-xs text-gray-500 mb-1">Name</label>
+                <input
+                  v-model="newAppName"
+                  type="text"
+                  placeholder="Application name"
+                  autocomplete="off"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  class="w-64 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
               <button
-                :data-testid="`confirm-delete-app-${app.id}`"
-                @click="confirmDeleteApp(app.id)"
-                class="text-xs text-red-600 hover:text-red-800 mr-1 font-medium"
-              >Yes</button>
-              <button
-                @click="pendingDeleteAppId = null"
-                class="text-xs text-gray-500 hover:text-gray-700"
-              >No</button>
-            </template>
-            <button
-              v-else
-              :data-testid="`delete-app-${app.id}`"
-              @click="startDeleteApp(app.id)"
-              class="text-xs text-red-500 hover:text-red-700"
-            >Delete</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+                type="submit"
+                :disabled="!newAppName.trim()"
+                class="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >Create</button>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="flex-1 flex items-center justify-center text-gray-400 text-sm">
+        Select a team to view applications
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { api } from '../api/client.js'
 import { useSession } from '../composables/useSession.js'
 
 const { currentUser } = useSession()
 
-const teams = ref([])
-const selectedTeamId = ref('')
+const allTeams = ref([])
+const teamSearch = ref('')
+const loadingTeams = ref(true)
+const teamsError = ref(null)
+
+const selectedTeam = ref(null)
 const applications = ref([])
 const loadingApps = ref(false)
 const appsError = ref(null)
 const newAppName = ref('')
 const pendingDeleteAppId = ref(null)
 
-function teamName(teamId) {
-  const team = teams.value.find(t => t.id === teamId)
-  return team?.name || String(teamId)
+const filteredTeams = computed(() => {
+  const q = teamSearch.value.toLowerCase().trim()
+  if (!q) return allTeams.value
+  return allTeams.value.filter((t) => t.name.toLowerCase().includes(q))
+})
+
+async function selectTeam(team) {
+  selectedTeam.value = team
+  pendingDeleteAppId.value = null
+  appsError.value = null
+  await loadApplications(team.id)
 }
 
 async function loadApplications(teamId) {
-  if (!teamId) {
-    applications.value = []
-    return
-  }
   loadingApps.value = true
   appsError.value = null
   try {
-    applications.value = await api.applications(Number(teamId))
+    applications.value = await api.applications(teamId) ?? []
   } catch (e) {
     appsError.value = e.message
   } finally {
@@ -123,20 +169,16 @@ async function loadApplications(teamId) {
   }
 }
 
-function handleTeamChange() {
-  pendingDeleteAppId.value = null
-  loadApplications(selectedTeamId.value)
-}
-
 async function handleCreateApplication() {
-  if (!newAppName.value.trim() || !selectedTeamId.value) return
+  if (!newAppName.value.trim() || !selectedTeam.value) return
+  appsError.value = null
   try {
     await api.createApplication({
-      team_id: Number(selectedTeamId.value),
+      team_id: selectedTeam.value.id,
       name: newAppName.value.trim(),
     })
     newAppName.value = ''
-    await loadApplications(selectedTeamId.value)
+    await loadApplications(selectedTeam.value.id)
   } catch (e) {
     appsError.value = e.message
   }
@@ -147,20 +189,31 @@ function startDeleteApp(appId) {
 }
 
 async function confirmDeleteApp(appId) {
+  appsError.value = null
   try {
     await api.deleteApplication(appId)
     pendingDeleteAppId.value = null
-    await loadApplications(selectedTeamId.value)
+    await loadApplications(selectedTeam.value.id)
   } catch (e) {
     appsError.value = e.message
   }
 }
 
 onMounted(async () => {
+  loadingTeams.value = true
   try {
-    teams.value = await api.teams()
+    if (currentUser.value?.is_admin) {
+      // Admins see all teams so they can manage apps even if not a member
+      allTeams.value = await api.teams() ?? []
+    } else {
+      // Non-admins see only teams they belong to
+      const memberships = await api.myTeams() ?? []
+      allTeams.value = memberships.map((m) => ({ id: m.team_id, name: m.team_name }))
+    }
   } catch (e) {
-    appsError.value = e.message
+    teamsError.value = e.message
+  } finally {
+    loadingTeams.value = false
   }
 })
 </script>

--- a/frontend/src/views/TeamsView.vue
+++ b/frontend/src/views/TeamsView.vue
@@ -63,7 +63,6 @@
         <h2 class="text-lg font-semibold text-gray-900 mb-4">{{ selectedTeam.name }} — Members</h2>
 
         <div v-if="loadingMembers" class="text-gray-500 text-sm">Loading members...</div>
-        <div v-else-if="membersError" class="text-red-600 text-sm">{{ membersError }}</div>
         <div v-else>
           <!-- Members table -->
           <table class="min-w-full divide-y divide-gray-200 mb-6">
@@ -76,6 +75,11 @@
               </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
+              <tr v-if="members.length === 0">
+                <td colspan="4" class="px-4 py-8 text-center text-sm text-gray-400 italic">
+                  No members yet — add a first member to this team below
+                </td>
+              </tr>
               <tr v-for="member in members" :key="member.user_id">
                 <td class="px-4 py-3 text-sm font-medium text-gray-900">{{ member.user_name }}</td>
                 <td class="px-4 py-3 text-sm text-gray-500">{{ member.user_email }}</td>
@@ -112,18 +116,55 @@
             </tbody>
           </table>
 
+          <!-- Inline error banner -->
+          <div v-if="membersError" class="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-600 flex justify-between items-center">
+            <span>{{ membersError }}</span>
+            <button @click="membersError = null" class="ml-3 text-red-400 hover:text-red-600">✕</button>
+          </div>
+
           <!-- Add member form -->
           <div class="border-t border-gray-200 pt-4">
             <h3 class="text-sm font-medium text-gray-700 mb-3">Add Member</h3>
             <form @submit.prevent="handleAddMember" class="flex items-end gap-3">
-              <div>
-                <label class="block text-xs text-gray-500 mb-1">User ID</label>
+              <!-- User search combobox -->
+              <div class="relative" ref="userSearchContainer">
+                <label class="block text-xs text-gray-500 mb-1">User</label>
                 <input
-                  v-model="addMemberUserId"
+                  v-model="addMemberSearch"
                   type="text"
-                  placeholder="user-id"
-                  class="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  placeholder="Search by name or email"
+                  autocomplete="off"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  class="w-64 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  @input="onUserSearchInput"
+                  @focus="onUserSearchFocus"
+                  @keydown.escape="closeUserDropdown"
+                  @keydown.down.prevent="moveSelection(1)"
+                  @keydown.up.prevent="moveSelection(-1)"
+                  @keydown.enter.prevent="selectHighlighted"
                 />
+                <!-- Dropdown -->
+                <ul
+                  v-if="userDropdownOpen && filteredUsers.length > 0"
+                  class="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-48 overflow-y-auto"
+                >
+                  <li
+                    v-for="(user, idx) in filteredUsers"
+                    :key="user.id"
+                    class="px-3 py-2 text-sm cursor-pointer"
+                    :class="idx === highlightedIndex ? 'bg-indigo-50 text-indigo-700' : 'text-gray-700 hover:bg-gray-50'"
+                    @mousedown.prevent="selectUser(user)"
+                    @mouseover="highlightedIndex = idx"
+                  >
+                    <span class="font-medium">{{ user.name }}</span>
+                    <span class="text-gray-400 ml-1">{{ user.email }}</span>
+                  </li>
+                </ul>
+                <!-- No results hint -->
+                <p v-if="userDropdownOpen && addMemberSearch && filteredUsers.length === 0" class="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-md shadow-sm px-3 py-2 text-xs text-gray-400">
+                  No users found
+                </p>
               </div>
               <div>
                 <label class="block text-xs text-gray-500 mb-1">Role</label>
@@ -138,7 +179,8 @@
               </div>
               <button
                 type="submit"
-                class="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 transition-colors"
+                :disabled="!addMemberUserId"
+                class="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
               >Add</button>
             </form>
           </div>
@@ -153,7 +195,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { api } from '../api/client.js'
 
 const teams = ref([])
@@ -168,9 +210,64 @@ const membersError = ref(null)
 const newTeamName = ref('')
 const pendingDeleteTeamId = ref(null)
 
+// User search combobox state
+const allUsers = ref([])
+const addMemberSearch = ref('')
 const addMemberUserId = ref('')
 const addMemberRole = ref('member')
+const userDropdownOpen = ref(false)
+const highlightedIndex = ref(-1)
+const userSearchContainer = ref(null)
 const pendingRemoveMemberId = ref(null)
+
+const filteredUsers = computed(() => {
+  const q = addMemberSearch.value.toLowerCase().trim()
+  if (!q) return allUsers.value
+  return allUsers.value.filter(
+    (u) => u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q)
+  )
+})
+
+function onUserSearchInput() {
+  // Clear the selected ID whenever the user edits the search text
+  addMemberUserId.value = ''
+  userDropdownOpen.value = true
+  highlightedIndex.value = -1
+}
+
+function onUserSearchFocus() {
+  userDropdownOpen.value = true
+  highlightedIndex.value = -1
+}
+
+function closeUserDropdown() {
+  userDropdownOpen.value = false
+  highlightedIndex.value = -1
+}
+
+function selectUser(user) {
+  addMemberUserId.value = user.id
+  addMemberSearch.value = `${user.name} (${user.email})`
+  closeUserDropdown()
+}
+
+function moveSelection(delta) {
+  if (!userDropdownOpen.value || filteredUsers.value.length === 0) return
+  const max = filteredUsers.value.length - 1
+  highlightedIndex.value = Math.min(max, Math.max(0, highlightedIndex.value + delta))
+}
+
+function selectHighlighted() {
+  if (highlightedIndex.value >= 0 && filteredUsers.value[highlightedIndex.value]) {
+    selectUser(filteredUsers.value[highlightedIndex.value])
+  }
+}
+
+function handleClickOutside(e) {
+  if (userSearchContainer.value && !userSearchContainer.value.contains(e.target)) {
+    closeUserDropdown()
+  }
+}
 
 async function loadTeams() {
   loadingTeams.value = true
@@ -188,7 +285,7 @@ async function loadMembers(teamId) {
   loadingMembers.value = true
   membersError.value = null
   try {
-    members.value = await api.teamMembers(teamId)
+    members.value = await api.teamMembers(teamId) ?? []
   } catch (e) {
     membersError.value = e.message
   } finally {
@@ -237,13 +334,15 @@ async function confirmDeleteTeam(teamId) {
 }
 
 async function handleAddMember() {
-  if (!addMemberUserId.value.trim() || !selectedTeam.value) return
+  if (!addMemberUserId.value || !selectedTeam.value) return
+  membersError.value = null
   try {
     await api.addTeamMember(selectedTeam.value.id, {
-      user_id: addMemberUserId.value.trim(),
+      user_id: addMemberUserId.value,
       role: addMemberRole.value,
     })
     addMemberUserId.value = ''
+    addMemberSearch.value = ''
     addMemberRole.value = 'member'
     await loadMembers(selectedTeam.value.id)
   } catch (e) {
@@ -274,5 +373,12 @@ async function confirmRemoveMember(member) {
   }
 }
 
-onMounted(loadTeams)
+onMounted(async () => {
+  document.addEventListener('click', handleClickOutside)
+  await Promise.all([loadTeams(), api.users().then((u) => { allUsers.value = u || [] })])
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
 </script>

--- a/frontend/tests/unit/views/ApplicationsView.test.js
+++ b/frontend/tests/unit/views/ApplicationsView.test.js
@@ -18,6 +18,7 @@ vi.mock('@/composables/useSession.js', () => ({
 vi.mock('@/api/client.js', () => ({
   api: {
     teams: vi.fn(),
+    myTeams: vi.fn(),
     applications: vi.fn(),
     createApplication: vi.fn(),
     deleteApplication: vi.fn(),
@@ -34,9 +35,10 @@ function makeRouter() {
   })
 }
 
-const sampleTeams = [
-  { id: 1, name: 'Alpha Team', created_at: '2024-01-01T00:00:00Z' },
-  { id: 2, name: 'Beta Team', created_at: '2024-02-01T00:00:00Z' },
+// myTeams returns TeamMember-shaped objects with team_id / team_name
+const sampleMemberships = [
+  { team_id: 1, team_name: 'Alpha Team', user_id: 'u1', role: 'admin' },
+  { team_id: 2, team_name: 'Beta Team', user_id: 'u1', role: 'member' },
 ]
 
 const sampleApps = [
@@ -46,7 +48,11 @@ const sampleApps = [
 
 describe('ApplicationsView', () => {
   beforeEach(() => {
-    vi.mocked(api.teams).mockReset()
+    // Test user is admin, so the component calls api.teams() not api.myTeams()
+    vi.mocked(api.teams).mockResolvedValue(
+      sampleMemberships.map((m) => ({ id: m.team_id, name: m.team_name }))
+    )
+    vi.mocked(api.myTeams).mockResolvedValue(sampleMemberships)
     vi.mocked(api.applications).mockReset()
     vi.mocked(api.createApplication).mockReset()
     vi.mocked(api.deleteApplication).mockReset()
@@ -56,8 +62,19 @@ describe('ApplicationsView', () => {
     vi.restoreAllMocks()
   })
 
+  it('TestApplicationsViewTeamList: renders team names in left panel', async () => {
+    const router = makeRouter()
+    await router.push('/applications')
+    const wrapper = mount(ApplicationsView, { global: { plugins: [router] } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Alpha Team')
+    expect(wrapper.text()).toContain('Beta Team')
+    // Admin user hits api.teams(); non-admins would hit api.myTeams()
+    expect(api.teams).toHaveBeenCalledTimes(1)
+  })
+
   it('TestApplicationsViewLists: renders application names after selecting a team', async () => {
-    vi.mocked(api.teams).mockResolvedValue(sampleTeams)
     vi.mocked(api.applications).mockResolvedValue(sampleApps)
 
     const router = makeRouter()
@@ -65,10 +82,11 @@ describe('ApplicationsView', () => {
     const wrapper = mount(ApplicationsView, { global: { plugins: [router] } })
     await flushPromises()
 
-    // Select team 1 from the dropdown
-    const select = wrapper.find('select')
-    expect(select.exists()).toBe(true)
-    await select.setValue('1')
+    // Click the first team in the left panel
+    const teamItems = wrapper.findAll('li')
+    const alphaItem = teamItems.find((li) => li.text().includes('Alpha Team'))
+    expect(alphaItem).toBeDefined()
+    await alphaItem.trigger('click')
     await flushPromises()
 
     expect(api.applications).toHaveBeenCalledWith(1)
@@ -77,9 +95,8 @@ describe('ApplicationsView', () => {
   })
 
   it('TestApplicationsViewCreate: calls api.createApplication with form data', async () => {
-    vi.mocked(api.teams).mockResolvedValue(sampleTeams)
     vi.mocked(api.applications).mockResolvedValue(sampleApps)
-    vi.mocked(api.createApplication).mockResolvedValue({ id: 3, team_id: 1, name: 'MyApp', created_at: '2024-03-01T00:00:00Z' })
+    vi.mocked(api.createApplication).mockResolvedValue(null)
 
     const router = makeRouter()
     await router.push('/applications')
@@ -87,26 +104,26 @@ describe('ApplicationsView', () => {
     await flushPromises()
 
     // Select a team first
-    const select = wrapper.find('select')
-    await select.setValue('1')
+    const teamItems = wrapper.findAll('li')
+    const alphaItem = teamItems.find((li) => li.text().includes('Alpha Team'))
+    await alphaItem.trigger('click')
     await flushPromises()
 
-    // Find the app name input and fill it
-    const nameInput = wrapper.find('input[type="text"]')
+    // Find the app name input (the second text input — first is the team filter)
+    const inputs = wrapper.findAll('input[type="text"]')
+    const nameInput = inputs[inputs.length - 1]
     expect(nameInput.exists()).toBe(true)
     await nameInput.setValue('MyApp')
 
     // Submit the form
-    const form = wrapper.find('form')
-    expect(form.exists()).toBe(true)
-    await form.trigger('submit')
+    const forms = wrapper.findAll('form')
+    await forms[forms.length - 1].trigger('submit')
     await flushPromises()
 
     expect(api.createApplication).toHaveBeenCalledWith({ team_id: 1, name: 'MyApp' })
   })
 
   it('TestApplicationsViewDelete: calls api.deleteApplication with app id', async () => {
-    vi.mocked(api.teams).mockResolvedValue(sampleTeams)
     vi.mocked(api.applications).mockResolvedValue(sampleApps)
     vi.mocked(api.deleteApplication).mockResolvedValue(null)
 
@@ -116,8 +133,9 @@ describe('ApplicationsView', () => {
     await flushPromises()
 
     // Select a team
-    const select = wrapper.find('select')
-    await select.setValue('1')
+    const teamItems = wrapper.findAll('li')
+    const alphaItem = teamItems.find((li) => li.text().includes('Alpha Team'))
+    await alphaItem.trigger('click')
     await flushPromises()
 
     // Find and click the delete button for app 1

--- a/frontend/tests/unit/views/TeamsView.test.js
+++ b/frontend/tests/unit/views/TeamsView.test.js
@@ -24,6 +24,7 @@ vi.mock('@/api/client.js', () => ({
     addTeamMember: vi.fn(),
     removeTeamMember: vi.fn(),
     updateTeamMemberRole: vi.fn(),
+    users: vi.fn().mockResolvedValue([]),
   },
 }))
 
@@ -56,6 +57,7 @@ describe('TeamsView', () => {
     vi.mocked(api.addTeamMember).mockReset()
     vi.mocked(api.removeTeamMember).mockReset()
     vi.mocked(api.updateTeamMemberRole).mockReset()
+    vi.mocked(api.users).mockResolvedValue([])
   })
 
   afterEach(() => {

--- a/internal/api/handler/teams.go
+++ b/internal/api/handler/teams.go
@@ -127,7 +127,7 @@ func AdminAddTeamMember(store storage.Storage) http.HandlerFunc {
 			model.WriteError(w, model.ErrInternal("failed to add team member"))
 			return
 		}
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 
@@ -190,7 +190,7 @@ func AdminUpdateTeamMemberRole(store storage.Storage) http.HandlerFunc {
 			model.WriteError(w, model.ErrInternal("failed to update team member role"))
 			return
 		}
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/storage/sqlite/identity.go
+++ b/internal/storage/sqlite/identity.go
@@ -56,7 +56,7 @@ func (s *Storage) ListUsers(ctx context.Context) ([]*storage.User, error) {
 	}
 	defer rows.Close()
 
-	var users []*storage.User
+	users := make([]*storage.User, 0)
 	for rows.Next() {
 		u := &storage.User{}
 		if err := rows.Scan(&u.ID, &u.Email, &u.Name, &u.IsAdmin, &u.CreatedAt, &u.LastSeen); err != nil {
@@ -104,7 +104,7 @@ func (s *Storage) ListTeams(ctx context.Context) ([]*storage.Team, error) {
 	}
 	defer rows.Close()
 
-	var teams []*storage.Team
+	teams := make([]*storage.Team, 0)
 	for rows.Next() {
 		t := &storage.Team{}
 		if err := rows.Scan(&t.ID, &t.Name, &t.CreatedAt); err != nil {
@@ -162,7 +162,7 @@ func (s *Storage) ListTeamMembers(ctx context.Context, teamID int64) ([]*storage
 	}
 	defer rows.Close()
 
-	var members []*storage.TeamMember
+	members := make([]*storage.TeamMember, 0)
 	for rows.Next() {
 		m := &storage.TeamMember{}
 		if err := rows.Scan(&m.TeamID, &m.UserID, &m.Role, &m.UserEmail, &m.UserName); err != nil {
@@ -189,7 +189,7 @@ func (s *Storage) ListMyTeams(ctx context.Context, userID string) ([]*storage.Te
 	}
 	defer rows.Close()
 
-	var memberships []*storage.TeamMember
+	memberships := make([]*storage.TeamMember, 0)
 	for rows.Next() {
 		m := &storage.TeamMember{}
 		if err := rows.Scan(&m.TeamID, &m.UserID, &m.Role, &m.TeamName); err != nil {
@@ -239,7 +239,7 @@ func (s *Storage) ListApplications(ctx context.Context, teamID int64) ([]*storag
 	}
 	defer rows.Close()
 
-	var apps []*storage.Application
+	apps := make([]*storage.Application, 0)
 	for rows.Next() {
 		a := &storage.Application{}
 		if err := rows.Scan(&a.ID, &a.TeamID, &a.Name, &a.CreatedAt); err != nil {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -98,38 +98,38 @@ type Storage interface {
 // ID is the OIDC subject identifier (sub claim) — NOT an internal UUID.
 // Using the sub claim directly avoids fragile account reconciliation.
 type User struct {
-	ID        string    // OIDC sub claim — the stable identity from PocketID
-	Email     string
-	Name      string
-	IsAdmin   bool
-	CreatedAt time.Time
-	LastSeen  time.Time
+	ID        string    `json:"id"`       // OIDC sub claim — the stable identity from PocketID
+	Email     string    `json:"email"`
+	Name      string    `json:"name"`
+	IsAdmin   bool      `json:"is_admin"`
+	CreatedAt time.Time `json:"created_at"`
+	LastSeen  time.Time `json:"last_seen"`
 }
 
 // Team represents a named group that owns applications.
 type Team struct {
-	ID        int64
-	Name      string
-	CreatedAt time.Time
+	ID        int64     `json:"id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // TeamMember represents a user's membership in a team with a role.
 type TeamMember struct {
-	TeamID    int64
-	UserID    string // OIDC sub of the user
-	Role      string // "admin", "member", or "viewer"
+	TeamID    int64  `json:"team_id"`
+	UserID    string `json:"user_id"` // OIDC sub of the user
+	Role      string `json:"role"`    // "admin", "member", or "viewer"
 	// Joined fields for convenience:
-	UserEmail string
-	UserName  string
-	TeamName  string
+	UserEmail string `json:"user_email"`
+	UserName  string `json:"user_name"`
+	TeamName  string `json:"team_name"`
 }
 
 // Application represents an app scoped to a team.
 type Application struct {
-	ID        int64
-	TeamID    int64
-	Name      string
-	CreatedAt time.Time
+	ID        int64     `json:"id"`
+	TeamID    int64     `json:"team_id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // CostOverride records a user-supplied mapping or custom spec for a proxy model name.


### PR DESCRIPTION
## Summary

Fixes discovered during Phase 1 live testing (UAT session 2026-03-25).

### Storage fixes
- **JSON struct tags** added to `User`, `Team`, `TeamMember`, `Application` — Go was serializing PascalCase field names; frontend expected `name`, `email`, `is_admin`, `last_seen`, `team_id`, etc.
- **Nil slice → empty slice** in all `List*` functions in `identity.go` — Go encodes a nil slice as JSON `null`, which caused Vue render errors and infinite loading spinners on empty teams/members/applications

### Backend HTTP status fixes
- `AdminAddTeamMember`: `201 Created` → `204 No Content` — no response body was being sent, triggering a JSON parse error in the frontend on every successful add
- `AdminUpdateTeamMemberRole`: `200 OK` → `204 No Content` — same root cause

### Teams view
- Replace raw User ID input with a **name/email search combobox** backed by `GET /admin/users`; selection stores the OIDC `sub` internally while showing a friendly display string
- `data-1p-ignore` / `data-lpignore` / `autocomplete=off` to suppress password manager overlays
- Error banner moved inline (was replacing the whole member panel); table stays visible on error
- **Empty-state row** spanning all 4 columns when a team has no members

### Applications view — full redesign
- Replaced dropdown + flat table with **two-panel layout** matching the Teams screen
- Left panel: filterable team list; admins see all teams (`api.teams`), non-admins see only their teams (`api.myTeams`) — this also fixes the blank list after delete/recreate since the admin may not be a member of the new team
- Right panel: `"{team} — Applications"` header, `NAME / CREATED / ACTIONS` table, empty-state row, dismissible error banner, and inline "New Application" form
- Defensive `?? []` on all application list responses

## Test plan

- [ ] Sign in, navigate to Teams — verify member rows show Name and Email correctly
- [ ] Add a member via the combobox — verify no JSON parse error and member appears immediately
- [ ] Remove a member — verify no errors
- [ ] Select a team with no members — verify empty-state message appears
- [ ] Navigate to Applications — verify teams are listed in the left panel
- [ ] Create and delete an application — verify no errors
- [ ] Delete a team and recreate it — verify it reappears on the Applications page immediately (admin path)
- [ ] Verify 1Password does not offer to fill the user search or app name fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)