### PR TITLE
fix(storage): prevent SQLITE_BUSY errors under concurrent requests

### DIFF
--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -22,10 +22,24 @@ func New(dbPath string) (*Storage, error) {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
+	// Serialize all connections through a single connection. WAL mode still
+	// allows readers to run concurrently at the OS level, but constraining the
+	// pool to one open connection ensures write transactions queue up within Go
+	// rather than racing on separate file descriptors and triggering SQLITE_BUSY.
+	db.SetMaxOpenConns(1)
+
 	// Enable WAL mode for better concurrency
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("setting journal mode: %w", err)
+	}
+
+	// Wait up to 5 s before returning SQLITE_BUSY. This is a backstop for any
+	// lock contention that slips past the single-connection pool limit (e.g. an
+	// external process or a second server instance sharing the same file).
+	if _, err := db.Exec("PRAGMA busy_timeout = 5000"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("setting busy timeout: %w", err)
 	}
 
 	// Enable foreign key enforcement — required for ON DELETE CASCADE


### PR DESCRIPTION
## Summary

- Sets `db.SetMaxOpenConns(1)` so all goroutines queue through a single SQLite connection rather than racing for the write lock on separate file descriptors
- Adds `PRAGMA busy_timeout = 5000` as a backstop so SQLite waits up to 5 s before returning `SQLITE_BUSY` (covers contention from external processes sharing the DB file)

Closes pridkett/simple-llm-proxy#21

## Why this works

The settings page fires several concurrent API requests (`/admin/users`, `/admin/me`, session reads, etc.). Without a pool limit, `database/sql` can open multiple connections to the same SQLite file simultaneously. Even in WAL mode, concurrent write transactions contend for the single writer slot. With `busy_timeout = 0` (the default), the second writer immediately gets `SQLITE_BUSY` → 500.

`SetMaxOpenConns(1)` makes Go serialize at the pool level, eliminating the race before it reaches SQLite. `busy_timeout` handles the residual case where an external tool or second server instance shares the file.

## Test plan
- [ ] All existing Go tests pass (`make test`)
- [ ] Settings page no longer returns 500 on rapid reloads
- [ ] Concurrent requests to `/admin/users`, `/admin/me`, `/admin/teams` succeed consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)