### PR TITLE
fix(spend-flush): add latency_ms to FlushKeySpend INSERT

### DIFF
--- a/internal/storage/sqlite/apikeys.go
+++ b/internal/storage/sqlite/apikeys.go
@@ -196,9 +196,9 @@ func (s *Storage) GetKeySpendTotals(ctx context.Context) (map[int64]float64, err
 // (including flush rows) to restore the accumulator accurately.
 func (s *Storage) FlushKeySpend(ctx context.Context, keyID int64, total float64) error {
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO usage_logs (api_key_id, total_cost, model, provider, endpoint, request_time, request_id, status_code)
+		INSERT INTO usage_logs (api_key_id, total_cost, model, provider, endpoint, request_time, request_id, status_code, latency_ms)
 		VALUES (?, ?, '_flush', '_flush', '_flush', datetime('now'),
-		        'flush-' || cast(strftime('%s','now') as text), 0)
+		        'flush-' || cast(strftime('%s','now') as text), 0, 0)
 	`, keyID, total)
 	if err != nil {
 		return fmt.Errorf("flush key spend: %w", err)


### PR DESCRIPTION
## Summary

- `FlushKeySpend` was missing `latency_ms` in its `INSERT INTO usage_logs` statement
- `latency_ms INTEGER NOT NULL` was added by Phase 4 migration 15, but the flush INSERT was never updated
- Every 30-second spend flush was failing silently; per-key spend was never persisted to SQLite

## Fix

Added `latency_ms, 0` to the sentinel flush row INSERT. Flush rows have no real latency — `0` is the correct placeholder.

## Test plan

- [x] `go build ./...` passes
- [x] All `internal/storage/...` tests pass including `TestGetSpendSummary` and `TestFlushKeySpend`
- [x] Spend flush no longer logs `WRN spend flush failed` errors at runtime

Implements pridkett/simple-llm-proxy#34

🤖 Generated with [Claude Code](https://claude.com/claude-code)