### PR TITLE
fix(session): always return 401 JSON for unauthenticated admin requests

### DIFF
--- a/internal/api/middleware/session.go
+++ b/internal/api/middleware/session.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/pwagstro/simple_llm_proxy/internal/model"
@@ -23,35 +22,29 @@ func UserFromContext(ctx context.Context) *storage.User {
 }
 
 // RequireSession validates the SCS session and injects the user into context.
-// For API callers (Accept: application/json or XHR), returns 401 JSON on missing/invalid session.
-// For browser navigation, returns 302 redirect to /login.
+// All unauthenticated requests receive a 401 JSON response.
+//
+// This middleware is only applied to /admin/* routes (see router.go), which are
+// exclusively called by the Vue SPA via JavaScript fetch(). The SPA uses hash-
+// based routing (createWebHashHistory), so browsers never navigate directly to
+// /admin/* paths. Therefore header-based detection of "browser vs API caller"
+// is unnecessary — every request here is an API call.
 func RequireSession(store storage.Storage, sm *scs.SessionManager) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			userID := sm.GetString(r.Context(), "user_id")
 			if userID == "" {
-				respondAuthRequired(w, r)
+				model.WriteError(w, model.ErrUnauthorized("authentication required"))
 				return
 			}
 			user, err := store.GetUser(r.Context(), userID)
 			if err != nil || user == nil {
 				sm.Destroy(r.Context())
-				respondAuthRequired(w, r)
+				model.WriteError(w, model.ErrUnauthorized("authentication required"))
 				return
 			}
 			ctx := context.WithValue(r.Context(), ContextKeyUser, user)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
-}
-
-func respondAuthRequired(w http.ResponseWriter, r *http.Request) {
-	acceptsJSON := strings.Contains(r.Header.Get("Accept"), "application/json") ||
-		strings.Contains(r.Header.Get("Content-Type"), "application/json") ||
-		r.Header.Get("X-Requested-With") == "XMLHttpRequest"
-	if acceptsJSON {
-		model.WriteError(w, model.ErrUnauthorized("authentication required"))
-		return
-	}
-	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }

--- a/internal/api/middleware/session_test.go
+++ b/internal/api/middleware/session_test.go
@@ -227,9 +227,9 @@ func TestRequireSession(t *testing.T) {
 	}
 }
 
-// TestRequireSessionMissing verifies the two response modes when no session exists:
-//   - Accept: text/html (browser nav)  → 302 redirect to /login
-//   - Accept: application/json (API)   → 401 JSON
+// TestRequireSessionMissing verifies that unauthenticated requests always receive
+// 401 JSON regardless of Accept header. All /admin/* routes are API-only (the Vue
+// SPA uses hash-based routing, so browsers never navigate directly to these paths).
 func TestRequireSessionMissing(t *testing.T) {
 	sm := newTestSessionManager()
 	store := &mockSessionStorage{}
@@ -241,50 +241,47 @@ func TestRequireSessionMissing(t *testing.T) {
 	protected := sm.LoadAndSave(RequireSession(store, sm)(handler))
 
 	tests := []struct {
-		name           string
-		acceptHeader   string
-		wantStatus     int
-		wantRedirect   bool
+		name         string
+		acceptHeader string
 	}{
 		{
-			name:         "browser nav gets redirect",
+			name:         "text/html accept still gets 401 JSON",
 			acceptHeader: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-			wantStatus:   http.StatusSeeOther,
-			wantRedirect: true,
 		},
 		{
-			name:         "API caller gets 401 JSON",
+			name:         "application/json accept gets 401 JSON",
 			acceptHeader: "application/json",
-			wantStatus:   http.StatusUnauthorized,
-			wantRedirect: false,
+		},
+		{
+			name:         "wildcard accept gets 401 JSON",
+			acceptHeader: "*/*",
+		},
+		{
+			name:         "no accept header gets 401 JSON",
+			acceptHeader: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/admin/status", nil)
-			req.Header.Set("Accept", tt.acceptHeader)
+			if tt.acceptHeader != "" {
+				req.Header.Set("Accept", tt.acceptHeader)
+			}
 
 			rr := httptest.NewRecorder()
 			protected.ServeHTTP(rr, req)
 
-			if rr.Code != tt.wantStatus {
-				t.Errorf("expected status %d, got %d", tt.wantStatus, rr.Code)
+			if rr.Code != http.StatusUnauthorized {
+				t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
 			}
 
-			if tt.wantRedirect {
-				location := rr.Header().Get("Location")
-				if location != "/login" {
-					t.Errorf("expected redirect to /login, got: %q", location)
-				}
-			} else {
-				var body map[string]interface{}
-				if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
-					t.Fatalf("response body is not valid JSON: %v", err)
-				}
-				if _, ok := body["error"]; !ok {
-					t.Errorf("expected JSON body with 'error' field, got: %v", body)
-				}
+			var body map[string]interface{}
+			if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+				t.Fatalf("response body is not valid JSON: %v", err)
+			}
+			if _, ok := body["error"]; !ok {
+				t.Errorf("expected JSON body with 'error' field, got: %v", body)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Remove the brittle header-sniffing heuristic (`Accept`, `Content-Type`, `X-Requested-With`) from `RequireSession` middleware that attempted to distinguish API callers from browser navigation
- Always return 401 JSON for unauthenticated `/admin/*` requests — the Vue SPA uses hash-based routing (`createWebHashHistory`), so browsers never navigate directly to these paths
- Update tests to verify consistent 401 JSON responses regardless of `Accept` header value (including `text/html`, `*/*`, and missing header)

Closes pridkett/simple-llm-proxy#19

## Test plan

- [x] `go test ./...` passes (all 23 packages)
- [ ] Manual: confirm unauthenticated `GET /admin/status` with `Accept: text/html` returns 401 JSON, not 302 redirect
- [ ] Manual: confirm Vue SPA login flow still works end-to-end (OIDC login, session cookie, admin API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)