### PR TITLE
fix(teams-view): restrict UI to user role and fix error display

### DIFF
--- a/frontend/src/views/TeamsView.vue
+++ b/frontend/src/views/TeamsView.vue
@@ -10,47 +10,53 @@
             Teams
           </div>
           <div v-if="loadingTeams" class="px-3 py-3 text-gray-500 text-sm">Loading...</div>
-          <div v-else-if="teamsError" class="px-3 py-3 text-red-600 text-sm">{{ teamsError }}</div>
-          <ul v-else>
-            <li
-              v-for="team in teams"
-              :key="team.id"
-              :data-testid="`team-item-${team.id}`"
-              class="flex items-center justify-between px-3 py-2 cursor-pointer text-sm border-b border-gray-100 last:border-0"
-              :class="selectedTeam?.id === team.id ? 'bg-indigo-50 text-indigo-700 font-medium' : 'text-gray-700 hover:bg-gray-50'"
-              @click="selectTeam(team)"
-            >
-              <span>{{ team.name }}</span>
-              <div>
-                <!-- Confirmation inline delete UI -->
-                <template v-if="pendingDeleteTeamId === team.id">
-                  <span class="text-xs text-gray-500 mr-1">Delete?</span>
+          <template v-else>
+            <!-- Inline error banner for teams (doesn't replace the list) -->
+            <div v-if="teamsError" class="px-3 py-2 bg-red-50 border-b border-red-200 text-sm text-red-600 flex justify-between items-center">
+              <span>{{ teamsError }}</span>
+              <button @click="teamsError = null" class="ml-2 text-red-400 hover:text-red-600 text-xs">✕</button>
+            </div>
+            <ul>
+              <li
+                v-for="team in teams"
+                :key="team.id"
+                :data-testid="`team-item-${team.id}`"
+                class="flex items-center justify-between px-3 py-2 cursor-pointer text-sm border-b border-gray-100 last:border-0"
+                :class="selectedTeam?.id === team.id ? 'bg-indigo-50 text-indigo-700 font-medium' : 'text-gray-700 hover:bg-gray-50'"
+                @click="selectTeam(team)"
+              >
+                <span>{{ team.name }}</span>
+                <div v-if="isAdmin">
+                  <!-- Confirmation inline delete UI (admin only) -->
+                  <template v-if="pendingDeleteTeamId === team.id">
+                    <span class="text-xs text-gray-500 mr-1">Delete?</span>
+                    <button
+                      :data-testid="`confirm-delete-${team.id}`"
+                      @click.stop="confirmDeleteTeam(team.id)"
+                      class="text-xs text-red-600 hover:text-red-800 mr-1 font-medium"
+                    >Yes</button>
+                    <button
+                      @click.stop="cancelDeleteTeam"
+                      class="text-xs text-gray-500 hover:text-gray-700"
+                    >No</button>
+                  </template>
                   <button
-                    :data-testid="`confirm-delete-${team.id}`"
-                    @click.stop="confirmDeleteTeam(team.id)"
-                    class="text-xs text-red-600 hover:text-red-800 mr-1 font-medium"
-                  >Yes</button>
-                  <button
-                    @click.stop="cancelDeleteTeam"
-                    class="text-xs text-gray-500 hover:text-gray-700"
-                  >No</button>
-                </template>
-                <button
-                  v-else
-                  :data-testid="`delete-team-${team.id}`"
-                  @click.stop="startDeleteTeam(team.id)"
-                  class="text-xs text-red-500 hover:text-red-700 ml-2"
-                >Delete</button>
-              </div>
-            </li>
-            <li v-if="teams.length === 0 && !loadingTeams" class="px-3 py-3 text-sm text-gray-400 italic">
-              No teams yet
-            </li>
-          </ul>
+                    v-else
+                    :data-testid="`delete-team-${team.id}`"
+                    @click.stop="startDeleteTeam(team.id)"
+                    class="text-xs text-red-500 hover:text-red-700 ml-2"
+                  >Delete</button>
+                </div>
+              </li>
+              <li v-if="teams.length === 0 && !loadingTeams" class="px-3 py-3 text-sm text-gray-400 italic">
+                No teams yet
+              </li>
+            </ul>
+          </template>
         </div>
 
-        <!-- Create team form -->
-        <form @submit.prevent="handleCreateTeam" class="mt-3 flex gap-2">
+        <!-- Create team form (admin only) -->
+        <form v-if="isAdmin" @submit.prevent="handleCreateTeam" class="mt-3 flex gap-2">
           <input
             v-model="newTeamName"
             type="text"
@@ -79,13 +85,13 @@
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Role</th>
-                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+                <th v-if="isAdmin" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
               </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
               <tr v-if="members.length === 0">
-                <td colspan="4" class="px-4 py-8 text-center text-sm text-gray-400 italic">
-                  No members yet — add a first member to this team below
+                <td :colspan="isAdmin ? 4 : 3" class="px-4 py-8 text-center text-sm text-gray-400 italic">
+                  No members yet<template v-if="isAdmin"> — add a first member to this team below</template>
                 </td>
               </tr>
               <tr v-for="member in members" :key="member.user_id">
@@ -93,6 +99,7 @@
                 <td class="px-4 py-3 text-sm text-gray-500">{{ member.user_email }}</td>
                 <td class="px-4 py-3 text-sm">
                   <select
+                    v-if="isAdmin"
                     :value="member.role"
                     @change="handleRoleChange(member, $event.target.value)"
                     class="border border-gray-300 rounded px-2 py-1 text-sm"
@@ -101,8 +108,9 @@
                     <option value="member">member</option>
                     <option value="viewer">viewer</option>
                   </select>
+                  <span v-else class="text-gray-600">{{ member.role }}</span>
                 </td>
-                <td class="px-4 py-3 text-sm">
+                <td v-if="isAdmin" class="px-4 py-3 text-sm">
                   <template v-if="pendingRemoveMemberId === member.user_id">
                     <span class="text-xs text-gray-500 mr-1">Remove {{ member.user_name }}?</span>
                     <button
@@ -130,8 +138,8 @@
             <button @click="membersError = null" class="ml-3 text-red-400 hover:text-red-600">✕</button>
           </div>
 
-          <!-- Add member form -->
-          <div class="border-t border-gray-200 pt-4">
+          <!-- Add member form (admin only) -->
+          <div v-if="isAdmin" class="border-t border-gray-200 pt-4">
             <h3 class="text-sm font-medium text-gray-700 mb-3">Add Member</h3>
             <form @submit.prevent="handleAddMember" class="flex items-end gap-3">
               <!-- User search combobox -->
@@ -205,6 +213,10 @@
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { api } from '../api/client.js'
+import { useSession } from '../composables/useSession.js'
+
+const { currentUser } = useSession()
+const isAdmin = computed(() => !!currentUser.value?.is_admin)
 
 const teams = ref([])
 const loadingTeams = ref(true)
@@ -281,7 +293,8 @@ async function loadTeams() {
   loadingTeams.value = true
   teamsError.value = null
   try {
-    teams.value = await api.teams()
+    const result = isAdmin.value ? await api.teams() : await api.myTeams()
+    teams.value = result ?? []
   } catch (e) {
     teamsError.value = e.message
   } finally {
@@ -383,7 +396,12 @@ async function confirmRemoveMember(member) {
 
 onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
-  await Promise.all([loadTeams(), api.users().then((u) => { allUsers.value = u || [] })])
+  const tasks = [loadTeams()]
+  // Only admins need the full user list (for the add-member search combobox)
+  if (isAdmin.value) {
+    tasks.push(api.users().then((u) => { allUsers.value = u || [] }))
+  }
+  await Promise.all(tasks)
 })
 
 onBeforeUnmount(() => {

--- a/frontend/tests/unit/views/TeamsView.test.js
+++ b/frontend/tests/unit/views/TeamsView.test.js
@@ -3,11 +3,14 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { ref } from 'vue'
 
-// Mock useSession to control auth state
+// --- Controllable session mock ---
+// We need to be able to switch between admin and non-admin users per test.
+const mockCurrentUser = ref({ id: 'u1', email: 'admin@example.com', name: 'Admin', is_admin: true })
+
 vi.mock('@/composables/useSession.js', () => ({
   useSession: () => ({
     isAuthenticated: ref(true),
-    currentUser: ref({ id: 'u1', email: 'admin@example.com', name: 'Admin', is_admin: true }),
+    currentUser: mockCurrentUser,
     loading: ref(false),
     fetchCurrentUser: vi.fn().mockResolvedValue(true),
     clearSession: vi.fn(),
@@ -18,6 +21,7 @@ vi.mock('@/composables/useSession.js', () => ({
 vi.mock('@/api/client.js', () => ({
   api: {
     teams: vi.fn(),
+    myTeams: vi.fn(),
     createTeam: vi.fn(),
     deleteTeam: vi.fn(),
     teamMembers: vi.fn(),
@@ -50,7 +54,10 @@ const sampleMembers = [
 
 describe('TeamsView', () => {
   beforeEach(() => {
+    // Default to admin user
+    mockCurrentUser.value = { id: 'u1', email: 'admin@example.com', name: 'Admin', is_admin: true }
     vi.mocked(api.teams).mockReset()
+    vi.mocked(api.myTeams).mockReset()
     vi.mocked(api.createTeam).mockReset()
     vi.mocked(api.deleteTeam).mockReset()
     vi.mocked(api.teamMembers).mockReset()
@@ -142,5 +149,111 @@ describe('TeamsView', () => {
     expect(api.teamMembers).toHaveBeenCalledWith(1)
     expect(wrapper.text()).toContain('Alice')
     expect(wrapper.text()).toContain('Bob')
+  })
+
+  // --- Non-admin tests ---
+
+  it('TestTeamsViewNonAdminUsesMyTeams: non-admin calls api.myTeams instead of api.teams', async () => {
+    mockCurrentUser.value = { id: 'u2', email: 'user@example.com', name: 'User', is_admin: false }
+    vi.mocked(api.myTeams).mockResolvedValue([sampleTeams[0]])
+
+    const router = makeRouter()
+    await router.push('/teams')
+    const wrapper = mount(TeamsView, { global: { plugins: [router] } })
+    await flushPromises()
+
+    expect(api.myTeams).toHaveBeenCalledTimes(1)
+    expect(api.teams).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Alpha Team')
+  })
+
+  it('TestTeamsViewNonAdminHidesCreateTeam: non-admin does not see create team form', async () => {
+    mockCurrentUser.value = { id: 'u2', email: 'user@example.com', name: 'User', is_admin: false }
+    vi.mocked(api.myTeams).mockResolvedValue(sampleTeams)
+
+    const router = makeRouter()
+    await router.push('/teams')
+    const wrapper = mount(TeamsView, { global: { plugins: [router] } })
+    await flushPromises()
+
+    // The create form should not exist
+    const form = wrapper.find('form')
+    expect(form.exists()).toBe(false)
+  })
+
+  it('TestTeamsViewNonAdminHidesDeleteButtons: non-admin does not see delete buttons', async () => {
+    mockCurrentUser.value = { id: 'u2', email: 'user@example.com', name: 'User', is_admin: false }
+    vi.mocked(api.myTeams).mockResolvedValue(sampleTeams)
+
+    const router = makeRouter()
+    await router.push('/teams')
+    const wrapper = mount(TeamsView, { global: { plugins: [router] } })
+    await flushPromises()
+
+    const deleteBtn = wrapper.find('[data-testid="delete-team-1"]')
+    expect(deleteBtn.exists()).toBe(false)
+  })
+
+  it('TestTeamsViewNonAdminReadOnlyMembers: non-admin sees members read-only without actions column', async () => {
+    mockCurrentUser.value = { id: 'u2', email: 'user@example.com', name: 'User', is_admin: false }
+    vi.mocked(api.myTeams).mockResolvedValue(sampleTeams)
+    vi.mocked(api.teamMembers).mockResolvedValue(sampleMembers)
+
+    const router = makeRouter()
+    await router.push('/teams')
+    const wrapper = mount(TeamsView, { global: { plugins: [router] } })
+    await flushPromises()
+
+    // Click a team to open detail
+    const teamItem = wrapper.find('[data-testid="team-item-1"]')
+    await teamItem.trigger('click')
+    await flushPromises()
+
+    // Members should be visible
+    expect(wrapper.text()).toContain('Alice')
+    expect(wrapper.text()).toContain('Bob')
+
+    // Actions column header should not exist
+    const headers = wrapper.findAll('th')
+    const headerTexts = headers.map((h) => h.text())
+    expect(headerTexts).not.toContain('Actions')
+
+    // Role should be displayed as plain text, not a select dropdown
+    const selects = wrapper.findAll('table select')
+    expect(selects.length).toBe(0)
+
+    // Remove buttons should not exist
+    expect(wrapper.text()).not.toContain('Remove')
+
+    // Add member form should not exist
+    expect(wrapper.text()).not.toContain('Add Member')
+  })
+
+  it('TestTeamsViewErrorDoesNotReplaceList: error on create does not hide team list', async () => {
+    vi.mocked(api.teams).mockResolvedValue(sampleTeams)
+    vi.mocked(api.createTeam).mockRejectedValue(new Error('Forbidden'))
+
+    const router = makeRouter()
+    await router.push('/teams')
+    const wrapper = mount(TeamsView, { global: { plugins: [router] } })
+    await flushPromises()
+
+    // Both teams visible initially
+    expect(wrapper.text()).toContain('Alpha Team')
+    expect(wrapper.text()).toContain('Beta Team')
+
+    // Try to create a team (will fail)
+    const nameInput = wrapper.find('input[type="text"]')
+    await nameInput.setValue('Bad Team')
+    const form = wrapper.find('form')
+    await form.trigger('submit')
+    await flushPromises()
+
+    // Error should be shown inline
+    expect(wrapper.text()).toContain('Forbidden')
+
+    // Teams should still be visible (not replaced by error)
+    expect(wrapper.text()).toContain('Alpha Team')
+    expect(wrapper.text()).toContain('Beta Team')
   })
 })


### PR DESCRIPTION
## Summary

Fixes #47 — Non-admin users see all teams and broken UI states in TeamsView.

- **Non-admins now see only their teams**: `loadTeams()` calls `api.myTeams()` for non-admins instead of `api.teams()` (admin-only endpoint)
- **Create Team / Delete Team buttons hidden** for non-admin users via `v-if="isAdmin"` guards
- **Member detail is read-only for non-admins**: role displayed as plain text (not editable dropdown), Actions column hidden, Add Member form hidden
- **Error display is now inline**: team list errors show as a dismissible banner above the list instead of replacing it with `v-else-if`, so errors from any operation never destroy the visible team list
- **User list only loaded for admins**: the `api.users()` call (used for the add-member search combobox) is skipped for non-admins who don't see that UI

## Test plan

- [x] All 178 existing frontend tests pass (`npm test`)
- [x] 5 new tests added for non-admin scenarios:
  - Non-admin calls `api.myTeams()` instead of `api.teams()`
  - Create Team form hidden for non-admins
  - Delete Team buttons hidden for non-admins
  - Members shown read-only without Actions column for non-admins
  - Error on create team does not hide existing team list
- [ ] Manual verification: log in as non-admin, confirm only own teams visible
- [ ] Manual verification: log in as admin, confirm full CRUD still works

This PR implements pridkett/simple-llm-proxy#47

🤖 Generated with [Claude Code](https://claude.com/claude-code)