### PR TITLE
feat(dev): add `make dev` to start backend and frontend together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test clean frontend-install frontend-dev frontend-build frontend-test
+.PHONY: build run test clean dev frontend-install frontend-dev frontend-build frontend-test
 
 # Build the proxy binary
 build:
@@ -11,6 +11,10 @@ run: build
 # Run with example config
 run-example: build
 	./bin/proxy -config config.yaml.example
+
+# Start backend + frontend dev servers (requires op CLI and op.env)
+dev: build
+	@./scripts/dev.sh
 
 # Run tests
 test:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# dev.sh — Start backend and frontend dev servers with secrets from 1Password.
+# Usage: ./scripts/dev.sh  (or: make dev)
+# Ctrl+C kills both processes.
+
+set -euo pipefail
+trap 'kill 0' EXIT
+
+echo "Starting backend on :8080 and frontend on :5173..."
+echo ""
+
+op run --env-file op.env --no-masking -- make run 2>&1 | sed 's/^/[backend]  /' &
+op run --env-file op.env --no-masking -- make frontend-dev 2>&1 | sed 's/^/[frontend] /' &
+
+wait


### PR DESCRIPTION
## Summary

Implements pridkett/simple-llm-proxy#10 — adds a single command to start both the backend and frontend dev servers.

- `make dev` starts both processes in parallel with `op run` for secrets injection
- Output prefixed with `[backend]` and `[frontend]` labels
- `Ctrl+C` cleanly kills both processes via `trap 'kill 0' EXIT`

## Usage
```bash
make dev
```

## Test plan
- [x] `make -n dev` shows correct command chain
- [x] `scripts/dev.sh` is executable
- [ ] `make dev` starts both servers and shows prefixed output
- [ ] Ctrl+C kills both processes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)