### PR TITLE
perf(session): disable SCS IdleTimeout to eliminate read-only session writes

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -84,7 +84,16 @@ func main() {
 		sm.Store = &sqlite.SessionStore{DB: sqliteStore.DB()}
 	}
 	sm.Lifetime = 24 * time.Hour
-	sm.IdleTimeout = 2 * time.Hour
+	// IdleTimeout is disabled (zero value) so SCS does not slide the session
+	// expiry on every authenticated request.  When IdleTimeout > 0, SCS calls
+	// CommitCtx on every request to push the expiry window forward — even when
+	// no session data has changed — which causes unnecessary SQLite writes and
+	// was the root cause of SQLITE_BUSY errors before serialization was added
+	// in #21.  With IdleTimeout = 0, sessions live for their full Lifetime
+	// (24 h) regardless of activity and CommitCtx is only called when data
+	// actually changes (login, logout, etc.).
+	// See: https://github.com/pridkett/simple-llm-proxy/issues/26
+	sm.IdleTimeout = 0
 	sm.Cookie.Name = "proxy_session"
 	sm.Cookie.HttpOnly = true
 	sm.Cookie.Secure = !cfg.OIDCSettings.DevMode // true in production, false in local HTTP dev

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -26,6 +26,11 @@ func New(dbPath string) (*Storage, error) {
 	// allows readers to run concurrently at the OS level, but constraining the
 	// pool to one open connection ensures write transactions queue up within Go
 	// rather than racing on separate file descriptors and triggering SQLITE_BUSY.
+	//
+	// NOTE: This is SQLite-specific. If the storage layer is ever migrated to
+	// PostgreSQL, MySQL, or another RDBMS, this limit should be removed (or
+	// raised significantly) so the connection pool can handle concurrent queries
+	// across multiple goroutines.
 	db.SetMaxOpenConns(1)
 
 	// Enable WAL mode for better concurrency
@@ -37,6 +42,10 @@ func New(dbPath string) (*Storage, error) {
 	// Wait up to 5 s before returning SQLITE_BUSY. This is a backstop for any
 	// lock contention that slips past the single-connection pool limit (e.g. an
 	// external process or a second server instance sharing the same file).
+	//
+	// NOTE: This is a SQLite-specific PRAGMA. It has no equivalent in other
+	// databases (PostgreSQL/MySQL handle lock waits differently). Remove this
+	// block if migrating away from SQLite.
 	if _, err := db.Exec("PRAGMA busy_timeout = 5000"); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("setting busy timeout: %w", err)


### PR DESCRIPTION
## Summary

Fixes pridkett/simple-llm-proxy#26 — eliminates unnecessary SQLite writes on every authenticated request.

- Set `sm.IdleTimeout = 0` so SCS only writes when session data changes (login/logout)
- Sessions still live for their full 24h Lifetime
- Added documentation comments on `SetMaxOpenConns(1)` and `PRAGMA busy_timeout` noting they're SQLite-specific

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go build ./...` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)