### PR TITLE
feat(observability): add X-Request-ID correlation IDs across logs and events

### DIFF
--- a/frontend/src/views/LogsView.vue
+++ b/frontend/src/views/LogsView.vue
@@ -15,6 +15,7 @@
             <thead class="bg-gray-50">
               <tr>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Time</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Request ID</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Model</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Provider</th>
                 <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Endpoint</th>
@@ -27,6 +28,9 @@
               <tr v-for="log in logsData.logs" :key="log.request_id" class="hover:bg-gray-50 transition-colors">
                 <td class="px-4 py-3 text-gray-500 whitespace-nowrap text-xs">
                   {{ formatDate(log.request_time) }}
+                </td>
+                <td class="px-4 py-3 text-gray-500 font-mono text-xs whitespace-nowrap" :title="log.request_id">
+                  {{ truncateID(log.request_id) }}
                 </td>
                 <td class="px-4 py-3 font-medium">{{ log.model }}</td>
                 <td class="px-4 py-3 text-gray-600 capitalize">{{ log.provider }}</td>
@@ -43,7 +47,7 @@
                 </td>
               </tr>
               <tr v-if="!logsData.logs?.length">
-                <td colspan="7" class="px-4 py-12 text-center text-gray-500">
+                <td colspan="8" class="px-4 py-12 text-center text-gray-500">
                   No request logs yet. Logs appear after sending requests through the proxy.
                 </td>
               </tr>
@@ -120,5 +124,10 @@ function nextPage() {
 
 function formatDate(iso) {
   return new Date(iso).toLocaleString()
+}
+
+function truncateID(id) {
+  if (!id) return ''
+  return id.length > 8 ? id.slice(0, 8) + '...' : id
 }
 </script>

--- a/internal/api/handler/chat.go
+++ b/internal/api/handler/chat.go
@@ -125,8 +125,10 @@ func ChatCompletions(r *router.Router, store storage.Storage, sa *keystore.Spend
 			return resp, nil, err
 		})
 
+		requestID := middleware.RequestIDFromContext(ctx)
+
 		// Emit routing events to webhook dispatcher (D-01: handler layer, after Route() returns).
-		emitRoutingEvents(dispatcher, r, result, chatReq.Model)
+		emitRoutingEvents(dispatcher, r, result, chatReq.Model, requestID)
 
 		if result.Error != nil {
 			// Check for budget exhaustion specifically (BUDGET-04).
@@ -147,9 +149,9 @@ func ChatCompletions(r *router.Router, store storage.Storage, sa *keystore.Spend
 		budget := r.BudgetManager()
 
 		if chatReq.Stream {
-			handleStreamingResponse(ctx, w, result, r, store, sa, cm, budget, result.PoolName, apiKeyID, startTime)
+			handleStreamingResponse(ctx, w, result, r, store, sa, cm, budget, result.PoolName, apiKeyID, startTime, requestID)
 		} else {
-			handleNonStreamingResponse(w, result, r, store, sa, cm, budget, result.PoolName, apiKeyID, startTime)
+			handleNonStreamingResponse(w, result, r, store, sa, cm, budget, result.PoolName, apiKeyID, startTime, requestID)
 		}
 	}
 }
@@ -165,12 +167,13 @@ func handleNonStreamingResponse(
 	poolName string,
 	apiKeyID *int64,
 	startTime time.Time,
+	requestID string,
 ) {
 	r.ReportSuccess(result.DeploymentUsed)
 
 	// Log the request if storage is available
 	if store != nil && result.Response != nil && result.Response.Usage != nil {
-		go logRequest(store, sa, cm, budget, poolName, apiKeyID, result.DeploymentUsed, "/v1/chat/completions", result.Response.Usage, http.StatusOK, startTime, false)
+		go logRequest(store, sa, cm, budget, poolName, apiKeyID, result.DeploymentUsed, "/v1/chat/completions", result.Response.Usage, http.StatusOK, startTime, false, requestID)
 	}
 
 	router.SetRouteHeaders(w, result)
@@ -190,6 +193,7 @@ func handleStreamingResponse(
 	poolName string,
 	apiKeyID *int64,
 	startTime time.Time,
+	requestID string,
 ) {
 	stream := result.Stream
 	defer stream.Close()
@@ -230,7 +234,7 @@ func handleStreamingResponse(
 				usage = &model.Usage{}
 			}
 			if store != nil {
-				go logRequest(store, sa, cm, budget, poolName, apiKeyID, result.DeploymentUsed, "/v1/chat/completions", usage, http.StatusOK, startTime, true)
+				go logRequest(store, sa, cm, budget, poolName, apiKeyID, result.DeploymentUsed, "/v1/chat/completions", usage, http.StatusOK, startTime, true, requestID)
 			}
 			return
 		}
@@ -263,10 +267,11 @@ func handleStreamingResponse(
 // logRequest writes the request log to storage, credits the spend accumulator,
 // and credits the pool budget manager.
 // Called asynchronously (via goroutine) after each successful request.
+// requestID is the correlation ID from the X-Request-ID middleware.
 // apiKeyID is nil when the request was authenticated via master key.
 // budget/poolName may be nil/empty for non-pool models.
 // isStreaming indicates whether this was a streaming or non-streaming request.
-func logRequest(store storage.Storage, sa *keystore.SpendAccumulator, cm *costmap.Manager, budget *router.PoolBudgetManager, poolName string, apiKeyID *int64, deployment *provider.Deployment, endpoint string, usage *model.Usage, status int, startTime time.Time, isStreaming bool) {
+func logRequest(store storage.Storage, sa *keystore.SpendAccumulator, cm *costmap.Manager, budget *router.PoolBudgetManager, poolName string, apiKeyID *int64, deployment *provider.Deployment, endpoint string, usage *model.Usage, status int, startTime time.Time, isStreaming bool, requestID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -278,7 +283,7 @@ func logRequest(store storage.Storage, sa *keystore.SpendAccumulator, cm *costma
 	}
 
 	log := &storage.RequestLog{
-		RequestID:     fmt.Sprintf("%d", time.Now().UnixNano()),
+		RequestID:     requestID,
 		APIKeyID:      apiKeyID,
 		Model:         deployment.ModelName,
 		Provider:      deployment.ProviderName,
@@ -310,20 +315,25 @@ func logRequest(store storage.Storage, sa *keystore.SpendAccumulator, cm *costma
 // routing anomalies (failover, budget exhaustion, pool cooldown).
 // Per D-01: event emission happens in the handler layer after Route() returns.
 // Per D-03: events fire on every qualifying occurrence, not debounced.
-func emitRoutingEvents(dispatcher *webhook.WebhookDispatcher, r *router.Router, result *router.RouteResult, model string) {
+// requestID is threaded into each event's Context map for traceability.
+func emitRoutingEvents(dispatcher *webhook.WebhookDispatcher, r *router.Router, result *router.RouteResult, model string, requestID string) {
 	if dispatcher == nil {
 		return
 	}
 
 	// provider_failover: failover occurred AND request ultimately succeeded (D-02)
 	if len(result.FailoverReasons) > 0 && result.Error == nil {
-		dispatcher.Emit(webhook.NewProviderFailoverEvent(model, result))
+		ev := webhook.NewProviderFailoverEvent(model, result)
+		ev.Context["request_id"] = requestID
+		dispatcher.Emit(ev)
 	}
 
 	// budget_exhausted: all pools exhausted for this model (D-02)
 	for _, reason := range result.FailoverReasons {
 		if reason == router.FailoverBudgetExhausted {
-			dispatcher.Emit(webhook.NewBudgetExhaustedEvent(model, result))
+			ev := webhook.NewBudgetExhaustedEvent(model, result)
+			ev.Context["request_id"] = requestID
+			dispatcher.Emit(ev)
 			break
 		}
 	}
@@ -333,7 +343,9 @@ func emitRoutingEvents(dispatcher *webhook.WebhookDispatcher, r *router.Router, 
 	if result.PoolName != "" {
 		pool := r.GetPool(result.PoolName)
 		if pool != nil && len(pool.Members) > 0 && r.IsPoolFullyCooled(pool) {
-			dispatcher.Emit(webhook.NewPoolCooldownEvent(pool.Name, pool.Members))
+			ev := webhook.NewPoolCooldownEvent(pool.Name, pool.Members)
+			ev.Context["request_id"] = requestID
+			dispatcher.Emit(ev)
 		}
 	}
 }

--- a/internal/api/handler/chat_test.go
+++ b/internal/api/handler/chat_test.go
@@ -667,7 +667,7 @@ func TestStreamIsStreamingFlag_STREAM05(t *testing.T) {
 		usage := &model.Usage{PromptTokens: 10, CompletionTokens: 5}
 
 		// Call logRequest with isStreaming=false (simulating non-streaming path)
-		logRequest(store, nil, nil, nil, "", nil, deployment, "/v1/chat/completions", usage, http.StatusOK, time.Now(), false)
+		logRequest(store, nil, nil, nil, "", nil, deployment, "/v1/chat/completions", usage, http.StatusOK, time.Now(), false, "")
 
 		// Wait for the log to be written (logRequest may run in goroutine in production,
 		// but here we call it synchronously for test determinism).

--- a/internal/api/handler/embeddings.go
+++ b/internal/api/handler/embeddings.go
@@ -87,7 +87,8 @@ func Embeddings(r *router.Router, store storage.Storage, sa *keystore.SpendAccum
 		})
 
 		// Emit routing events to webhook dispatcher.
-		emitRoutingEvents(dispatcher, r, result, embReq.Model)
+		requestID := middleware.RequestIDFromContext(ctx)
+		emitRoutingEvents(dispatcher, r, result, embReq.Model, requestID)
 
 		if result.Error != nil {
 			// Check for budget exhaustion specifically (BUDGET-04).
@@ -110,7 +111,7 @@ func Embeddings(r *router.Router, store storage.Storage, sa *keystore.SpendAccum
 
 		// Log the request if storage is available
 		if store != nil && embResp != nil && embResp.Usage != nil {
-			go logRequest(store, sa, cm, budget, result.PoolName, apiKeyID, result.DeploymentUsed, "/v1/embeddings", embResp.Usage, http.StatusOK, startTime, false)
+			go logRequest(store, sa, cm, budget, result.PoolName, apiKeyID, result.DeploymentUsed, "/v1/embeddings", embResp.Usage, http.StatusOK, startTime, false, requestID)
 		}
 
 		router.SetRouteHeaders(w, result)

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -58,6 +58,11 @@ func Logging() func(http.Handler) http.Handler {
 				ev = log.Info()
 			}
 
+			// Include correlation ID if present in context.
+			if reqID := RequestIDFromContext(r.Context()); reqID != "" {
+				ev = ev.Str("request_id", reqID)
+			}
+
 			ev.Str("method", r.Method).
 				Str("path", r.URL.Path).
 				Int("status", rw.status).

--- a/internal/api/middleware/requestid.go
+++ b/internal/api/middleware/requestid.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+)
+
+// ContextKeyRequestID is the context key for the request correlation ID.
+const ContextKeyRequestID contextKey = "request_id"
+
+// RequestIDFromContext extracts the request correlation ID from the request context.
+// Returns an empty string if no request ID is present.
+func RequestIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(ContextKeyRequestID).(string)
+	return id
+}
+
+// RequestID returns middleware that assigns a unique correlation ID to each request.
+// If the incoming request already carries an X-Request-ID header, that value is
+// reused (pass-through). Otherwise a new UUID v4 is generated using crypto/rand.
+// The ID is stored in the request context and set as the X-Request-ID response header.
+func RequestID() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := r.Header.Get("X-Request-ID")
+			if id == "" {
+				id = newUUID()
+			}
+
+			// Set the response header so callers can correlate responses.
+			w.Header().Set("X-Request-ID", id)
+
+			ctx := context.WithValue(r.Context(), ContextKeyRequestID, id)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// newUUID generates a UUID v4 string using crypto/rand.
+// Format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx where y is one of {8,9,a,b}.
+func newUUID() string {
+	var uuid [16]byte
+	_, _ = rand.Read(uuid[:])
+
+	// Set version 4 (bits 12-15 of time_hi_and_version)
+	uuid[6] = (uuid[6] & 0x0f) | 0x40
+	// Set variant (bits 6-7 of clock_seq_hi_and_reserved)
+	uuid[8] = (uuid[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16])
+}

--- a/internal/api/middleware/requestid_test.go
+++ b/internal/api/middleware/requestid_test.go
@@ -1,0 +1,112 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+// uuidRegex matches a standard UUID v4 string.
+var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestRequestID_GeneratesUUID(t *testing.T) {
+	var gotID string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotID = RequestIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+
+	RequestID()(handler).ServeHTTP(rr, req)
+
+	if gotID == "" {
+		t.Fatal("expected request ID in context, got empty string")
+	}
+	if !uuidRegex.MatchString(gotID) {
+		t.Errorf("expected UUID v4 format, got %q", gotID)
+	}
+
+	// Response header must match the context value.
+	respHeader := rr.Header().Get("X-Request-ID")
+	if respHeader != gotID {
+		t.Errorf("response header X-Request-ID = %q, want %q", respHeader, gotID)
+	}
+}
+
+func TestRequestID_PassThroughExisting(t *testing.T) {
+	const existingID = "client-supplied-id-123"
+
+	var gotID string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotID = RequestIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", existingID)
+	rr := httptest.NewRecorder()
+
+	RequestID()(handler).ServeHTTP(rr, req)
+
+	if gotID != existingID {
+		t.Errorf("expected pass-through ID %q, got %q", existingID, gotID)
+	}
+
+	respHeader := rr.Header().Get("X-Request-ID")
+	if respHeader != existingID {
+		t.Errorf("response header X-Request-ID = %q, want %q", respHeader, existingID)
+	}
+}
+
+func TestRequestID_SetsResponseHeader(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+
+	RequestID()(handler).ServeHTTP(rr, req)
+
+	respHeader := rr.Header().Get("X-Request-ID")
+	if respHeader == "" {
+		t.Fatal("expected X-Request-ID response header, got empty")
+	}
+	if !uuidRegex.MatchString(respHeader) {
+		t.Errorf("expected UUID v4 format in response header, got %q", respHeader)
+	}
+}
+
+func TestRequestID_UniquePerRequest(t *testing.T) {
+	ids := make(map[string]bool)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := RequestIDFromContext(r.Context())
+		if ids[id] {
+			t.Errorf("duplicate request ID: %s", id)
+		}
+		ids[id] = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := RequestID()(handler)
+	for i := 0; i < 100; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		rr := httptest.NewRecorder()
+		mw.ServeHTTP(rr, req)
+	}
+
+	if len(ids) != 100 {
+		t.Errorf("expected 100 unique IDs, got %d", len(ids))
+	}
+}
+
+func TestRequestIDFromContext_Empty(t *testing.T) {
+	// When no middleware has run, RequestIDFromContext should return "".
+	id := RequestIDFromContext(httptest.NewRequest("GET", "/", nil).Context())
+	if id != "" {
+		t.Errorf("expected empty string, got %q", id)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -27,6 +27,7 @@ func NewRouter(r *router.Router, store storage.Storage, reloader *config.Reloade
 
 	// Global middleware
 	mux.Use(middleware.Recovery())
+	mux.Use(middleware.RequestID())
 	mux.Use(middleware.Logging())
 	mux.Use(middleware.CORS([]string{
 		"http://localhost:5173",


### PR DESCRIPTION
## Summary

Implements pridkett/simple-llm-proxy#49 — every request gets a UUID v4 correlation ID threaded through the entire lifecycle.

- **New middleware**: generates UUID or passes through existing `X-Request-ID` header
- **Structured logs**: zerolog includes `request_id` field
- **Request logs**: `usage_logs.request_id` stores the UUID (replaces nanosecond timestamp)
- **Webhook events**: `request_id` included in event context/payload
- **Frontend**: LogsView shows truncated Request ID column with full tooltip

Stacked on #58 (SCS perf fix).

## Test plan
- [x] `go test ./...` — all tests pass (5 new middleware tests)
- [x] `npm test` — 178 frontend tests pass
- [ ] Verify X-Request-ID header in response via curl/Network tab
- [ ] Verify request_id appears in zerolog output

🤖 Generated with [Claude Code](https://claude.com/claude-code)