### PR TITLE
fix(api): replace deprecated POST /v1/completions with 410 Gone

### DIFF
--- a/internal/api/handler/completions.go
+++ b/internal/api/handler/completions.go
@@ -3,34 +3,32 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
-
-	"github.com/pwagstro/simple_llm_proxy/internal/model"
 )
 
-// Completions handles POST /v1/completions requests (legacy endpoint).
-// This is a placeholder for future implementation.
+// deprecatedEndpointError is the JSON structure returned for deprecated endpoints.
+type deprecatedEndpointError struct {
+	Error deprecatedDetail `json:"error"`
+}
+
+type deprecatedDetail struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    int    `json:"code"`
+}
+
+// Completions handles POST /v1/completions requests.
+// This endpoint is deprecated — it returns 410 Gone directing clients
+// to use POST /v1/chat/completions instead.
 func Completions() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		model.WriteError(w, model.ErrBadRequest("legacy completions endpoint not implemented; use /v1/chat/completions instead"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusGone)
+		json.NewEncoder(w).Encode(deprecatedEndpointError{
+			Error: deprecatedDetail{
+				Message: "POST /v1/completions is deprecated. Use POST /v1/chat/completions instead.",
+				Type:    "deprecated_endpoint",
+				Code:    http.StatusGone,
+			},
+		})
 	}
 }
-
-// CompletionResponse represents a legacy completion response.
-type CompletionResponse struct {
-	ID      string              `json:"id"`
-	Object  string              `json:"object"`
-	Created int64               `json:"created"`
-	Model   string              `json:"model"`
-	Choices []CompletionChoice  `json:"choices"`
-	Usage   *model.Usage        `json:"usage,omitempty"`
-}
-
-// CompletionChoice represents a legacy completion choice.
-type CompletionChoice struct {
-	Text         string `json:"text"`
-	Index        int    `json:"index"`
-	FinishReason string `json:"finish_reason,omitempty"`
-}
-
-// Unused but kept for type reference
-var _ = json.Marshal

--- a/internal/api/handler/completions_test.go
+++ b/internal/api/handler/completions_test.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCompletions_Returns410Gone(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions", nil)
+	rr := httptest.NewRecorder()
+
+	Completions()(rr, req)
+
+	if rr.Code != http.StatusGone {
+		t.Errorf("expected status %d, got %d", http.StatusGone, rr.Code)
+	}
+
+	contentType := rr.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", contentType)
+	}
+
+	var resp deprecatedEndpointError
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+
+	if resp.Error.Type != "deprecated_endpoint" {
+		t.Errorf("expected error type %q, got %q", "deprecated_endpoint", resp.Error.Type)
+	}
+
+	if resp.Error.Code != http.StatusGone {
+		t.Errorf("expected error code %d, got %d", http.StatusGone, resp.Error.Code)
+	}
+
+	expectedMsg := "POST /v1/completions is deprecated. Use POST /v1/chat/completions instead."
+	if resp.Error.Message != expectedMsg {
+		t.Errorf("expected error message %q, got %q", expectedMsg, resp.Error.Message)
+	}
+}

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -63,7 +63,7 @@ func (s *Spec) Build() error {
 			},
 			&openapi3.Tag{
 				Name:        "Completions",
-				Description: "Legacy completion endpoints (deprecated)",
+				Description: "Legacy completion endpoints (deprecated — returns 410 Gone)",
 			},
 			&openapi3.Tag{
 				Name:        "Admin",

--- a/internal/openapi/operations.go
+++ b/internal/openapi/operations.go
@@ -173,39 +173,24 @@ func completionsPath() *openapi3.PathItem {
 	return &openapi3.PathItem{
 		Post: &openapi3.Operation{
 			Tags:        []string{"Completions"},
-			Summary:     "Create completion (deprecated)",
-			Description: "Creates a completion for the provided prompt. This is a legacy endpoint; use /v1/chat/completions instead.",
+			Summary:     "Create completion (deprecated — returns 410 Gone)",
+			Description: "This endpoint is deprecated and always returns 410 Gone. Use POST /v1/chat/completions instead.",
 			OperationID: "createCompletion",
 			Deprecated:  true,
 			Security:    &openapi3.SecurityRequirements{{bearerAuthName: []string{}}},
-			RequestBody: &openapi3.RequestBodyRef{
-				Value: &openapi3.RequestBody{
-					Required: true,
-					Content: openapi3.Content{
-						"application/json": &openapi3.MediaType{
-							Schema: &openapi3.SchemaRef{
-								Ref: "#/components/schemas/CompletionRequest",
-							},
-						},
-					},
-				},
-			},
 			Responses: openapi3.NewResponses(
-				openapi3.WithStatus(http.StatusOK, &openapi3.ResponseRef{
+				openapi3.WithStatus(http.StatusGone, &openapi3.ResponseRef{
 					Value: &openapi3.Response{
-						Description: strPtr("Successful response"),
+						Description: strPtr("Endpoint deprecated. Use POST /v1/chat/completions instead."),
 						Content: openapi3.Content{
 							"application/json": &openapi3.MediaType{
 								Schema: &openapi3.SchemaRef{
-									Ref: "#/components/schemas/ChatCompletionResponse",
+									Ref: "#/components/schemas/APIError",
 								},
 							},
 						},
 					},
 				}),
-				openapi3.WithStatus(http.StatusBadRequest, errorResponseRef("Invalid request")),
-				openapi3.WithStatus(http.StatusUnauthorized, errorResponseRef("Authentication failed")),
-				openapi3.WithStatus(http.StatusNotImplemented, errorResponseRef("Not implemented")),
 			),
 		},
 	}

--- a/internal/openapi/schemas.go
+++ b/internal/openapi/schemas.go
@@ -10,7 +10,6 @@ func buildSchemas() openapi3.Schemas {
 		// Request types
 		"ChatCompletionRequest":  chatCompletionRequestSchema(),
 		"EmbeddingsRequest":      embeddingsRequestSchema(),
-		"CompletionRequest":      completionRequestSchema(),
 		"Message":                messageSchema(),
 		"ContentPart":            contentPartSchema(),
 		"ImageURL":               imageURLSchema(),
@@ -189,88 +188,6 @@ func embeddingsRequestSchema() *openapi3.SchemaRef {
 						Type:        &openapi3.Types{"string"},
 						Description: "The format to return the embeddings in",
 						Enum:        []any{"float", "base64"},
-					},
-				},
-			},
-		},
-	}
-}
-
-func completionRequestSchema() *openapi3.SchemaRef {
-	return &openapi3.SchemaRef{
-		Value: &openapi3.Schema{
-			Type:        &openapi3.Types{"object"},
-			Required:    []string{"model", "prompt"},
-			Description: "Legacy completion request (deprecated)",
-			Properties: openapi3.Schemas{
-				"model": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"string"},
-						Description: "ID of the model to use",
-					},
-				},
-				"prompt": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Description: "The prompt to generate completions for",
-					},
-				},
-				"max_tokens": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"integer"},
-						Description: "Maximum number of tokens to generate",
-					},
-				},
-				"temperature": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"number"},
-						Description: "Sampling temperature",
-						Min:         ptr(0.0),
-						Max:         ptr(2.0),
-					},
-				},
-				"top_p": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"number"},
-						Description: "Nucleus sampling parameter",
-					},
-				},
-				"n": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"integer"},
-						Description: "Number of completions to generate",
-					},
-				},
-				"stream": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"boolean"},
-						Description: "Whether to stream partial progress",
-					},
-				},
-				"stop": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"array"},
-						Description: "Sequences where the API will stop generating",
-						Items: &openapi3.SchemaRef{
-							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
-						},
-					},
-				},
-				"presence_penalty": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"number"},
-						Description: "Penalty for new tokens based on presence",
-					},
-				},
-				"frequency_penalty": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"number"},
-						Description: "Penalty for new tokens based on frequency",
-					},
-				},
-				"user": &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type:        &openapi3.Types{"string"},
-						Description: "A unique identifier representing the end-user",
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

Fixes pridkett/simple-llm-proxy#8 — deprecated completions endpoint now returns a clear error instead of a confusing stub.

- `POST /v1/completions` returns 410 Gone with JSON message directing to `/v1/chat/completions`
- Removed dead `CompletionResponse`/`CompletionChoice` types
- Updated OpenAPI spec to reflect 410 response
- Removed unreferenced `CompletionRequest` schema

Stacked on #59 (X-Request-ID).

## Test plan
- [x] `go test ./...` — all tests pass (new completions_test.go)
- [x] `go build ./...` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)