### PR TITLE
feat(openrouter): add automatic model discovery via wildcard config

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pwagstro/simple_llm_proxy/internal/keystore"
 	"github.com/pwagstro/simple_llm_proxy/internal/logger"
 	"github.com/pwagstro/simple_llm_proxy/internal/openapi"
+	"github.com/pwagstro/simple_llm_proxy/internal/provider/openrouter"
 	"github.com/pwagstro/simple_llm_proxy/internal/router"
 	"github.com/pwagstro/simple_llm_proxy/internal/storage"
 	"github.com/pwagstro/simple_llm_proxy/internal/storage/sqlite"
@@ -32,7 +33,7 @@ import (
 	_ "github.com/pwagstro/simple_llm_proxy/internal/provider/minimax"
 	_ "github.com/pwagstro/simple_llm_proxy/internal/provider/ollama"
 	_ "github.com/pwagstro/simple_llm_proxy/internal/provider/openai"
-	_ "github.com/pwagstro/simple_llm_proxy/internal/provider/openrouter"
+	// openrouter is imported above (non-blank) for model discovery; init() still runs.
 	_ "github.com/pwagstro/simple_llm_proxy/internal/provider/vllm"
 )
 
@@ -52,6 +53,27 @@ func main() {
 
 	// Initialize structured logger before any other operations.
 	logger.Init(cfg.LogSettings)
+
+	// Register OpenRouter model discovery for wildcard expansion.
+	// When the config contains "openrouter/*", all available models are
+	// fetched from the OpenRouter API and registered as individual deployments.
+	reloader.SetDiscoveryProviders([]config.DiscoveryProvider{
+		{
+			Prefix:     "openrouter",
+			IsWildcard: openrouter.IsWildcard,
+			Discover:   openrouter.DiscoverModels,
+		},
+	})
+
+	// Expand wildcard entries (e.g., openrouter/*) before router creation.
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		if err := reloader.ExpandWildcardsOnConfig(ctx); err != nil {
+			log.Warn().Err(err).Msg("failed to expand wildcard model entries; continuing with static config")
+		}
+		cancel()
+		cfg = reloader.Config() // refresh cfg pointer after expansion
+	}
 
 	// Initialize storage (before router, so sticky sessions can use it)
 	var store storage.Storage

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
+// ModelDiscoverer is a function that fetches available models from a provider
+// and returns expanded ModelConfig entries. It is called during wildcard
+// expansion to discover models at startup.
+type ModelDiscoverer func(ctx context.Context, apiKey, apiBase string, template ModelConfig) ([]ModelConfig, error)
+
+// WildcardChecker is a function that returns true if a ModelConfig uses a
+// wildcard pattern that should trigger model discovery.
+type WildcardChecker func(mc ModelConfig) bool
+
+// DiscoveryProvider bundles a wildcard checker with a discovery function for a
+// specific provider (e.g., OpenRouter).
+type DiscoveryProvider struct {
+	// Prefix is the provider prefix to match (e.g., "openrouter").
+	Prefix string
+	// IsWildcard returns true if the model config uses a wildcard pattern.
+	IsWildcard WildcardChecker
+	// Discover fetches and returns expanded model configs.
+	Discover ModelDiscoverer
+}
+
+// ExpandWildcards processes the config's ModelList and expands any wildcard
+// entries using the registered discovery providers. Non-wildcard entries are
+// passed through unchanged. This must be called with a context (for HTTP
+// timeouts) after Parse() but before the router is created.
+func ExpandWildcards(ctx context.Context, cfg *Config, providers []DiscoveryProvider) error {
+	if len(providers) == 0 {
+		return nil
+	}
+
+	expanded := make([]ModelConfig, 0, len(cfg.ModelList))
+
+	for _, mc := range cfg.ModelList {
+		matched := false
+		for _, dp := range providers {
+			if dp.IsWildcard(mc) {
+				matched = true
+				apiKey := mc.LiteLLMParams.APIKey
+				apiBase := mc.LiteLLMParams.APIBase
+
+				log.Info().
+					Str("provider", dp.Prefix).
+					Str("api_base", apiBase).
+					Msg("discovering models via wildcard")
+
+				models, err := dp.Discover(ctx, apiKey, apiBase, mc)
+				if err != nil {
+					return fmt.Errorf("expanding wildcard for %s: %w", dp.Prefix, err)
+				}
+
+				log.Info().
+					Str("provider", dp.Prefix).
+					Int("count", len(models)).
+					Msg("discovered models")
+
+				expanded = append(expanded, models...)
+				break
+			}
+		}
+		if !matched {
+			expanded = append(expanded, mc)
+		}
+	}
+
+	cfg.ModelList = expanded
+	return nil
+}
+

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestExpandWildcardsNoProviders(t *testing.T) {
+	cfg := &Config{
+		ModelList: []ModelConfig{
+			{ModelName: "gpt-4", LiteLLMParams: LiteLLMParams{Model: "openai/gpt-4", APIKey: "key"}},
+		},
+	}
+
+	err := ExpandWildcards(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.ModelList) != 1 {
+		t.Errorf("expected 1 model, got %d", len(cfg.ModelList))
+	}
+}
+
+func TestExpandWildcardsPassthroughNonWildcard(t *testing.T) {
+	cfg := &Config{
+		ModelList: []ModelConfig{
+			{ModelName: "gpt-4", LiteLLMParams: LiteLLMParams{Model: "openai/gpt-4", APIKey: "key"}},
+			{ModelName: "claude-3", LiteLLMParams: LiteLLMParams{Model: "anthropic/claude-3", APIKey: "key2"}},
+		},
+	}
+
+	providers := []DiscoveryProvider{
+		{
+			Prefix:     "openrouter",
+			IsWildcard: func(mc ModelConfig) bool { return mc.LiteLLMParams.Model == "openrouter/*" },
+			Discover:   func(ctx context.Context, apiKey, apiBase string, template ModelConfig) ([]ModelConfig, error) { return nil, nil },
+		},
+	}
+
+	err := ExpandWildcards(context.Background(), cfg, providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.ModelList) != 2 {
+		t.Errorf("expected 2 models unchanged, got %d", len(cfg.ModelList))
+	}
+	if cfg.ModelList[0].ModelName != "gpt-4" {
+		t.Errorf("expected first model 'gpt-4', got %q", cfg.ModelList[0].ModelName)
+	}
+	if cfg.ModelList[1].ModelName != "claude-3" {
+		t.Errorf("expected second model 'claude-3', got %q", cfg.ModelList[1].ModelName)
+	}
+}
+
+func TestExpandWildcardsExpandsWildcard(t *testing.T) {
+	cfg := &Config{
+		ModelList: []ModelConfig{
+			{ModelName: "gpt-4", LiteLLMParams: LiteLLMParams{Model: "openai/gpt-4", APIKey: "openai-key"}},
+			{
+				ModelName: "openrouter-wildcard",
+				LiteLLMParams: LiteLLMParams{
+					Model:  "openrouter/*",
+					APIKey: "or-key",
+				},
+				RPM: 100,
+			},
+			{ModelName: "claude-3", LiteLLMParams: LiteLLMParams{Model: "anthropic/claude-3", APIKey: "anth-key"}},
+		},
+	}
+
+	providers := []DiscoveryProvider{
+		{
+			Prefix:     "openrouter",
+			IsWildcard: func(mc ModelConfig) bool { return mc.LiteLLMParams.Model == "openrouter/*" },
+			Discover: func(ctx context.Context, apiKey, apiBase string, template ModelConfig) ([]ModelConfig, error) {
+				return []ModelConfig{
+					{
+						ModelName:     "google/gemini-2.5-pro",
+						LiteLLMParams: LiteLLMParams{Model: "openrouter/google/gemini-2.5-pro", APIKey: apiKey},
+						RPM:           template.RPM,
+					},
+					{
+						ModelName:     "meta/llama-3-70b",
+						LiteLLMParams: LiteLLMParams{Model: "openrouter/meta/llama-3-70b", APIKey: apiKey},
+						RPM:           template.RPM,
+					},
+				}, nil
+			},
+		},
+	}
+
+	err := ExpandWildcards(context.Background(), cfg, providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be: gpt-4, gemini-2.5-pro, llama-3-70b, claude-3
+	if len(cfg.ModelList) != 4 {
+		t.Fatalf("expected 4 models after expansion, got %d", len(cfg.ModelList))
+	}
+
+	expectedNames := []string{
+		"gpt-4",
+		"google/gemini-2.5-pro",
+		"meta/llama-3-70b",
+		"claude-3",
+	}
+	for i, name := range expectedNames {
+		if cfg.ModelList[i].ModelName != name {
+			t.Errorf("model[%d]: expected %q, got %q", i, name, cfg.ModelList[i].ModelName)
+		}
+	}
+
+	// Verify discovered models inherited the API key
+	if cfg.ModelList[1].LiteLLMParams.APIKey != "or-key" {
+		t.Errorf("expected discovered model API key 'or-key', got %q", cfg.ModelList[1].LiteLLMParams.APIKey)
+	}
+}
+
+func TestExpandWildcardsDiscoverError(t *testing.T) {
+	cfg := &Config{
+		ModelList: []ModelConfig{
+			{
+				ModelName: "openrouter-wildcard",
+				LiteLLMParams: LiteLLMParams{
+					Model:  "openrouter/*",
+					APIKey: "or-key",
+				},
+			},
+		},
+	}
+
+	providers := []DiscoveryProvider{
+		{
+			Prefix:     "openrouter",
+			IsWildcard: func(mc ModelConfig) bool { return mc.LiteLLMParams.Model == "openrouter/*" },
+			Discover: func(ctx context.Context, apiKey, apiBase string, template ModelConfig) ([]ModelConfig, error) {
+				return nil, fmt.Errorf("connection refused")
+			},
+		},
+	}
+
+	err := ExpandWildcards(context.Background(), cfg, providers)
+	if err == nil {
+		t.Fatal("expected error when discovery fails")
+	}
+}
+
+func TestExpandWildcardsEmptyDiscovery(t *testing.T) {
+	cfg := &Config{
+		ModelList: []ModelConfig{
+			{ModelName: "gpt-4", LiteLLMParams: LiteLLMParams{Model: "openai/gpt-4", APIKey: "key"}},
+			{
+				ModelName: "openrouter-wildcard",
+				LiteLLMParams: LiteLLMParams{
+					Model:  "openrouter/*",
+					APIKey: "or-key",
+				},
+			},
+		},
+	}
+
+	providers := []DiscoveryProvider{
+		{
+			Prefix:     "openrouter",
+			IsWildcard: func(mc ModelConfig) bool { return mc.LiteLLMParams.Model == "openrouter/*" },
+			Discover: func(ctx context.Context, apiKey, apiBase string, template ModelConfig) ([]ModelConfig, error) {
+				return []ModelConfig{}, nil
+			},
+		},
+	}
+
+	err := ExpandWildcards(context.Background(), cfg, providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be just gpt-4, wildcard expanded to nothing
+	if len(cfg.ModelList) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(cfg.ModelList))
+	}
+	if cfg.ModelList[0].ModelName != "gpt-4" {
+		t.Errorf("expected model 'gpt-4', got %q", cfg.ModelList[0].ModelName)
+	}
+}

--- a/internal/config/reloader.go
+++ b/internal/config/reloader.go
@@ -1,11 +1,16 @@
 package config
 
-import "sync/atomic"
+import (
+	"context"
+	"sync/atomic"
+	"time"
+)
 
 // Reloader provides thread-safe config loading and hot-reloading.
 type Reloader struct {
-	path string
-	ptr  atomic.Pointer[Config]
+	path               string
+	ptr                atomic.Pointer[Config]
+	discoveryProviders []DiscoveryProvider
 }
 
 // NewReloader creates a Reloader that loads the config from path.
@@ -19,18 +24,49 @@ func NewReloader(path string) (*Reloader, error) {
 	return r, nil
 }
 
+// SetDiscoveryProviders registers discovery providers for wildcard expansion.
+// Must be called before ExpandWildcardsOnConfig or Reload to take effect.
+func (r *Reloader) SetDiscoveryProviders(providers []DiscoveryProvider) {
+	r.discoveryProviders = providers
+}
+
+// ExpandWildcardsOnConfig runs wildcard expansion on the currently loaded
+// config using the registered discovery providers. This should be called
+// once at startup after SetDiscoveryProviders and before the router is
+// created.
+func (r *Reloader) ExpandWildcardsOnConfig(ctx context.Context) error {
+	cfg := r.ptr.Load()
+	if err := ExpandWildcards(ctx, cfg, r.discoveryProviders); err != nil {
+		return err
+	}
+	r.ptr.Store(cfg)
+	return nil
+}
+
 // Config returns the current config.
 func (r *Reloader) Config() *Config {
 	return r.ptr.Load()
 }
 
 // Reload re-reads the config file and atomically replaces the current config.
+// If discovery providers are registered, wildcard entries are expanded before
+// the new config takes effect.
 // Returns the new config on success.
 func (r *Reloader) Reload() (*Config, error) {
 	cfg, err := Load(r.path)
 	if err != nil {
 		return nil, err
 	}
+
+	// Expand wildcards if any discovery providers are registered.
+	if len(r.discoveryProviders) > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := ExpandWildcards(ctx, cfg, r.discoveryProviders); err != nil {
+			return nil, err
+		}
+	}
+
 	r.ptr.Store(cfg)
 	return cfg, nil
 }

--- a/internal/provider/openrouter/discovery.go
+++ b/internal/provider/openrouter/discovery.go
@@ -1,0 +1,111 @@
+// Package openrouter implements the OpenRouter provider.
+// This file adds model discovery: fetching all available models from the
+// OpenRouter /models endpoint and expanding wildcard config entries.
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pwagstro/simple_llm_proxy/internal/config"
+)
+
+// modelListResponse is the OpenAI-compatible response from GET /models.
+type modelListResponse struct {
+	Data []modelEntry `json:"data"`
+}
+
+// modelEntry represents a single model in the OpenRouter model list.
+type modelEntry struct {
+	ID string `json:"id"`
+}
+
+// httpClient is an interface for HTTP requests, allowing test injection.
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// defaultClient is the production HTTP client with a reasonable timeout.
+var defaultClient httpClient = &http.Client{Timeout: 30 * time.Second}
+
+// DiscoverModels fetches the full model list from OpenRouter and returns
+// expanded ModelConfig entries, one per discovered model. Each entry inherits
+// the API key, extra headers, RPM, and TPM from the wildcard template.
+//
+// apiBase should be the base URL (e.g., "https://openrouter.ai/api/v1").
+// If empty, the default OpenRouter base URL is used.
+func DiscoverModels(ctx context.Context, apiKey, apiBase string, template config.ModelConfig) ([]config.ModelConfig, error) {
+	return discoverModelsWithClient(ctx, defaultClient, apiKey, apiBase, template)
+}
+
+// discoverModelsWithClient is the internal implementation that accepts an HTTP client
+// for testing.
+func discoverModelsWithClient(ctx context.Context, client httpClient, apiKey, apiBase string, template config.ModelConfig) ([]config.ModelConfig, error) {
+	base := defaultBaseURL
+	if apiBase != "" {
+		base = strings.TrimSuffix(apiBase, "/")
+	}
+
+	url := base + "/models"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating model list request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching model list from %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("model list request failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading model list response: %w", err)
+	}
+
+	var modelList modelListResponse
+	if err := json.Unmarshal(body, &modelList); err != nil {
+		return nil, fmt.Errorf("parsing model list response: %w", err)
+	}
+
+	configs := make([]config.ModelConfig, 0, len(modelList.Data))
+	for _, m := range modelList.Data {
+		if m.ID == "" {
+			continue
+		}
+
+		mc := config.ModelConfig{
+			ModelName: m.ID,
+			LiteLLMParams: config.LiteLLMParams{
+				Model:        "openrouter/" + m.ID,
+				APIKey:       template.LiteLLMParams.APIKey,
+				APIBase:      template.LiteLLMParams.APIBase,
+				ExtraHeaders: template.LiteLLMParams.ExtraHeaders,
+				ExtraParams:  template.LiteLLMParams.ExtraParams,
+			},
+			RPM: template.RPM,
+			TPM: template.TPM,
+		}
+		configs = append(configs, mc)
+	}
+
+	return configs, nil
+}
+
+// IsWildcard returns true if the model config uses a wildcard pattern
+// for OpenRouter model discovery (e.g., model: "openrouter/*").
+func IsWildcard(mc config.ModelConfig) bool {
+	model := mc.LiteLLMParams.Model
+	return model == "openrouter/*"
+}

--- a/internal/provider/openrouter/discovery_test.go
+++ b/internal/provider/openrouter/discovery_test.go
@@ -1,0 +1,308 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pwagstro/simple_llm_proxy/internal/config"
+)
+
+func TestDiscoverModels(t *testing.T) {
+	models := modelListResponse{
+		Data: []modelEntry{
+			{ID: "google/gemini-2.5-pro"},
+			{ID: "anthropic/claude-sonnet-4"},
+			{ID: "openai/gpt-4o"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Errorf("expected path /models, got %s", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-key" {
+			t.Errorf("expected Authorization 'Bearer test-key', got %q", auth)
+		}
+		json.NewEncoder(w).Encode(models)
+	}))
+	defer server.Close()
+
+	template := config.ModelConfig{
+		LiteLLMParams: config.LiteLLMParams{
+			APIKey: "test-key",
+		},
+		RPM: 100,
+		TPM: 50000,
+	}
+
+	result, err := DiscoverModels(context.Background(), "test-key", server.URL, template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 models, got %d", len(result))
+	}
+
+	// Check first model
+	if result[0].ModelName != "google/gemini-2.5-pro" {
+		t.Errorf("expected model_name 'google/gemini-2.5-pro', got %q", result[0].ModelName)
+	}
+	if result[0].LiteLLMParams.Model != "openrouter/google/gemini-2.5-pro" {
+		t.Errorf("expected litellm model 'openrouter/google/gemini-2.5-pro', got %q", result[0].LiteLLMParams.Model)
+	}
+	if result[0].LiteLLMParams.APIKey != "test-key" {
+		t.Errorf("expected api_key 'test-key', got %q", result[0].LiteLLMParams.APIKey)
+	}
+	if result[0].RPM != 100 {
+		t.Errorf("expected RPM 100, got %d", result[0].RPM)
+	}
+	if result[0].TPM != 50000 {
+		t.Errorf("expected TPM 50000, got %d", result[0].TPM)
+	}
+
+	// Check second model
+	if result[1].ModelName != "anthropic/claude-sonnet-4" {
+		t.Errorf("expected model_name 'anthropic/claude-sonnet-4', got %q", result[1].ModelName)
+	}
+	if result[1].LiteLLMParams.Model != "openrouter/anthropic/claude-sonnet-4" {
+		t.Errorf("expected litellm model 'openrouter/anthropic/claude-sonnet-4', got %q", result[1].LiteLLMParams.Model)
+	}
+
+	// Check third model
+	if result[2].ModelName != "openai/gpt-4o" {
+		t.Errorf("expected model_name 'openai/gpt-4o', got %q", result[2].ModelName)
+	}
+}
+
+func TestDiscoverModelsInheritsExtraHeaders(t *testing.T) {
+	models := modelListResponse{
+		Data: []modelEntry{
+			{ID: "google/gemini-2.5-pro"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(models)
+	}))
+	defer server.Close()
+
+	template := config.ModelConfig{
+		LiteLLMParams: config.LiteLLMParams{
+			APIKey: "test-key",
+			ExtraHeaders: map[string]string{
+				"HTTP-Referer": "https://myapp.com",
+				"X-Title":      "My App",
+			},
+		},
+		RPM: 50,
+	}
+
+	result, err := DiscoverModels(context.Background(), "test-key", server.URL, template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(result))
+	}
+
+	eh := result[0].LiteLLMParams.ExtraHeaders
+	if eh == nil {
+		t.Fatal("expected ExtraHeaders to be non-nil")
+	}
+	if eh["HTTP-Referer"] != "https://myapp.com" {
+		t.Errorf("expected HTTP-Referer 'https://myapp.com', got %q", eh["HTTP-Referer"])
+	}
+	if eh["X-Title"] != "My App" {
+		t.Errorf("expected X-Title 'My App', got %q", eh["X-Title"])
+	}
+}
+
+func TestDiscoverModelsInheritsAPIBase(t *testing.T) {
+	models := modelListResponse{
+		Data: []modelEntry{
+			{ID: "test/model"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(models)
+	}))
+	defer server.Close()
+
+	template := config.ModelConfig{
+		LiteLLMParams: config.LiteLLMParams{
+			APIKey:  "test-key",
+			APIBase: server.URL,
+		},
+	}
+
+	result, err := DiscoverModels(context.Background(), "test-key", server.URL, template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(result))
+	}
+
+	if result[0].LiteLLMParams.APIBase != server.URL {
+		t.Errorf("expected APIBase %q, got %q", server.URL, result[0].LiteLLMParams.APIBase)
+	}
+}
+
+func TestDiscoverModelsSkipsEmptyIDs(t *testing.T) {
+	models := modelListResponse{
+		Data: []modelEntry{
+			{ID: "google/gemini-2.5-pro"},
+			{ID: ""},
+			{ID: "openai/gpt-4o"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(models)
+	}))
+	defer server.Close()
+
+	template := config.ModelConfig{
+		LiteLLMParams: config.LiteLLMParams{
+			APIKey: "test-key",
+		},
+	}
+
+	result, err := DiscoverModels(context.Background(), "test-key", server.URL, template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 models (empty ID skipped), got %d", len(result))
+	}
+}
+
+func TestDiscoverModelsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	template := config.ModelConfig{
+		LiteLLMParams: config.LiteLLMParams{
+			APIKey: "test-key",
+		},
+	}
+
+	_, err := DiscoverModels(context.Background(), "test-key", server.URL, template)
+	if err == nil {
+		t.Fatal("expected error on 500 response")
+	}
+}
+
+func TestDiscoverModelsInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	template := config.ModelConfig{
+		LiteLLMParams: config.LiteLLMParams{
+			APIKey: "test-key",
+		},
+	}
+
+	_, err := DiscoverModels(context.Background(), "test-key", server.URL, template)
+	if err == nil {
+		t.Fatal("expected error on invalid JSON")
+	}
+}
+
+func TestDiscoverModelsEmptyList(t *testing.T) {
+	models := modelListResponse{
+		Data: []modelEntry{},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(models)
+	}))
+	defer server.Close()
+
+	template := config.ModelConfig{
+		LiteLLMParams: config.LiteLLMParams{
+			APIKey: "test-key",
+		},
+	}
+
+	result, err := DiscoverModels(context.Background(), "test-key", server.URL, template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 models, got %d", len(result))
+	}
+}
+
+func TestDiscoverModelsDefaultBaseURL(t *testing.T) {
+	// When apiBase is empty, the default base URL should be used.
+	// We can't easily test the actual URL without a mock, but we can
+	// verify that the function uses the custom apiBase when provided.
+	models := modelListResponse{
+		Data: []modelEntry{
+			{ID: "test/model"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(models)
+	}))
+	defer server.Close()
+
+	template := config.ModelConfig{
+		LiteLLMParams: config.LiteLLMParams{
+			APIKey: "test-key",
+		},
+	}
+
+	// With custom apiBase, should use the server URL
+	result, err := DiscoverModels(context.Background(), "test-key", server.URL, template)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(result))
+	}
+}
+
+func TestIsWildcard(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		expected bool
+	}{
+		{"wildcard", "openrouter/*", true},
+		{"specific model", "openrouter/google/gemini-2.5-pro", false},
+		{"openai model", "openai/gpt-4", false},
+		{"empty", "", false},
+		{"just openrouter", "openrouter/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := config.ModelConfig{
+				LiteLLMParams: config.LiteLLMParams{
+					Model: tt.model,
+				},
+			}
+			if got := IsWildcard(mc); got != tt.expected {
+				t.Errorf("IsWildcard(%q) = %v, want %v", tt.model, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add automatic model discovery for OpenRouter: when `model: "openrouter/*"` appears in the config, the proxy fetches all available models from the OpenRouter `/models` API at startup and registers each as an individual deployment
- Each discovered model inherits the wildcard entry's API key, extra headers, RPM, and TPM settings
- Discovery also runs on config hot-reload via the Reloader

## Implementation Details

**New files:**
- `internal/provider/openrouter/discovery.go` — `DiscoverModels()` fetches `GET {apiBase}/models` and returns expanded `ModelConfig` entries; `IsWildcard()` detects the `openrouter/*` pattern
- `internal/provider/openrouter/discovery_test.go` — 9 test cases covering success, error, empty lists, extra headers inheritance, etc.
- `internal/config/expand.go` — Generic `ExpandWildcards()` function with callback-based `DiscoveryProvider` pattern (avoids circular imports between config and openrouter packages)
- `internal/config/expand_test.go` — 5 test cases for wildcard expansion logic

**Modified files:**
- `internal/config/reloader.go` — Added `SetDiscoveryProviders()` and `ExpandWildcardsOnConfig()` so wildcard expansion works at startup and on hot-reload
- `cmd/proxy/main.go` — Wires OpenRouter discovery into startup; failures are non-fatal (proxy continues with static config)

## Usage

Add a single wildcard entry to `config.yaml`:

```yaml
model_list:
  - model_name: openrouter-all
    litellm_params:
      model: openrouter/*
      api_key: os.environ/OPENROUTER_API_KEY
    rpm: 100
```

At startup, this expands to one deployment per model available on OpenRouter (e.g., `google/gemini-2.5-pro`, `anthropic/claude-sonnet-4`, etc.).

## Test plan

- [x] `go test ./internal/provider/openrouter/...` — 16 tests pass (9 new discovery tests + 7 existing)
- [x] `go test ./internal/config/...` — 19 tests pass (5 new expand tests + 14 existing)
- [x] `go test ./...` — All Go tests pass
- [x] `cd frontend && npm test` — All 178 frontend tests pass
- [x] `make build` — Binary builds successfully

This PR implements pridkett/simple-llm-proxy#38

🤖 Generated with [Claude Code](https://claude.com/claude-code)